### PR TITLE
fix: treefy not attaching children to parent nodes

### DIFF
--- a/packages/helper/package.json
+++ b/packages/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/helper",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "license": "MIT",
   "main": "dist/index.cjs.js",
   "types": "dist/types/index.d.ts",

--- a/packages/helper/src/treefy.ts
+++ b/packages/helper/src/treefy.ts
@@ -10,7 +10,7 @@ export const treefy = <I extends { depth: number }>(input: I[]) => {
     if (top < item.depth && item.depth <= bottom + 1) {
       const idx = item.depth - top
       bottom = item.depth
-      ;(last[idx - 1].children ?? []).push(item)
+      ;(last[idx - 1].children ??= []).push(item)
       last[idx] = item
       continue
     }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/markdown",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "keywords": [
     "markdown"
@@ -47,7 +47,7 @@
     "@sakura-ui/core": "^0.4.0-beta.0"
   },
   "dependencies": {
-    "@sakura-ui/helper": "0.0.6",
+    "@sakura-ui/helper": "0.0.7",
     "github-slugger": "^2.0.0",
     "hastscript": "^9.0.0",
     "mdast-util-directive": "^3.0.0",


### PR DESCRIPTION
## Summary
- Fix a bug in `treefy` where children were not properly nested under their parent nodes in the generated menu tree

## Problem
`treefy` used `(?? [])` which created a temporary array without assigning it back to the parent node's `children` property. As a result, child headings appeared as top-level items instead of being nested.

**Before (bug):**
```
Menu
hogehoge1     ← H1
fugafuga      ← H2 (should be nested under hogehoge1, but appeared at root)
hogehoge2     ← H1
```

**After (fix):**
```
Menu
hogehoge1     ← H1
  fugafuga    ← H2 (correctly nested)
hogehoge2     ← H1
```

## Changes
- **`packages/helper/src/treefy.ts`** — Change `(last[idx - 1].children ?? [])` to `(last[idx - 1].children ??= [])` so the array is assigned to the parent node