### PR TITLE
chore: add tests to helper

### DIFF
--- a/packages/helper/package.json
+++ b/packages/helper/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@sakura-ui/helper",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.cjs.js",
   "types": "dist/types/index.d.ts",
   "exports": {
@@ -35,6 +36,7 @@
     "@types/react-dom": "catalog:",
     "happy-dom": "catalog:",
     "react": "catalog:",
-    "react-dom": "catalog:"
+    "react-dom": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/helper/tests/calc.test.ts
+++ b/packages/helper/tests/calc.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { mod } from '../src/calc'
+
+describe('mod', () => {
+  it('should return the remainder for positive numbers', () => {
+    expect(mod(5, 3)).toBe(2)
+  })
+
+  it('should return a positive result for negative dividend', () => {
+    expect(mod(-1, 3)).toBe(2)
+    expect(mod(-5, 3)).toBe(1)
+  })
+
+  it('should return 0 when evenly divisible', () => {
+    expect(mod(6, 3)).toBe(0)
+    expect(mod(7, 7)).toBe(0)
+  })
+
+  it('should return 0 when dividend is 0', () => {
+    expect(mod(0, 5)).toBe(0)
+  })
+})

--- a/packages/helper/tests/cx.test.ts
+++ b/packages/helper/tests/cx.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { cx } from '../src/cx'
+
+describe('cx', () => {
+  it('should join multiple class names with a space', () => {
+    expect(cx('foo', 'bar', 'baz')).toBe('foo bar baz')
+  })
+
+  it('should filter out falsy values', () => {
+    expect(cx('foo', false, 'bar', null, undefined, 0, '', 'baz')).toBe(
+      'foo bar baz'
+    )
+  })
+
+  it('should handle conditional class names', () => {
+    const isActive = true
+    const isDisabled = false
+    expect(cx('base', isActive && 'active', isDisabled && 'disabled')).toBe(
+      'base active'
+    )
+  })
+
+  it('should return an empty string when no arguments', () => {
+    expect(cx()).toBe('')
+  })
+
+  it('should handle a single class name', () => {
+    expect(cx('only')).toBe('only')
+  })
+})

--- a/packages/helper/tests/querySelector.test.ts
+++ b/packages/helper/tests/querySelector.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { focusableSelector } from '../src/querySelector'
+
+describe('focusableSelector', () => {
+  it('should be a string', () => {
+    expect(typeof focusableSelector).toBe('string')
+  })
+
+  it('should include common focusable element selectors', () => {
+    expect(focusableSelector).toContain('a[href]')
+    expect(focusableSelector).toContain('button')
+    expect(focusableSelector).toContain('input')
+    expect(focusableSelector).toContain('select')
+    expect(focusableSelector).toContain('textarea')
+  })
+
+  it('should exclude elements with negative tabindex', () => {
+    expect(focusableSelector).toContain(':not([tabindex^="-"])')
+  })
+
+  it('should exclude disabled elements for interactive elements', () => {
+    expect(focusableSelector).toContain(':not(:disabled)')
+  })
+})

--- a/packages/helper/tests/treefy.test.ts
+++ b/packages/helper/tests/treefy.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { treefy } from '../src/treefy'
+
+describe('treefy', () => {
+  it('should return an empty array for empty input', () => {
+    expect(treefy([])).toEqual([])
+  })
+
+  it('should keep flat items at the root level when all depths are the same', () => {
+    const input = [
+      { depth: 1, name: 'a' },
+      { depth: 1, name: 'b' },
+      { depth: 1, name: 'c' }
+    ]
+    expect(treefy(input)).toEqual([
+      { depth: 1, name: 'a' },
+      { depth: 1, name: 'b' },
+      { depth: 1, name: 'c' }
+    ])
+  })
+
+  it('should nest children under their parent', () => {
+    const input = [
+      { depth: 1, name: 'parent' },
+      { depth: 2, name: 'child1' },
+      { depth: 2, name: 'child2' }
+    ]
+    expect(treefy(input)).toEqual([
+      {
+        depth: 1,
+        name: 'parent',
+        children: [
+          { depth: 2, name: 'child1' },
+          { depth: 2, name: 'child2' }
+        ]
+      }
+    ])
+  })
+
+  it('should nest deeply (depth 1 -> 2 -> 3)', () => {
+    const input = [
+      { depth: 1, name: 'root' },
+      { depth: 2, name: 'child' },
+      { depth: 3, name: 'grandchild' }
+    ]
+    expect(treefy(input)).toEqual([
+      {
+        depth: 1,
+        name: 'root',
+        children: [
+          {
+            depth: 2,
+            name: 'child',
+            children: [{ depth: 3, name: 'grandchild' }]
+          }
+        ]
+      }
+    ])
+  })
+
+  it('should handle multiple root nodes with children', () => {
+    const input = [
+      { depth: 1, name: 'h1-first' },
+      { depth: 2, name: 'h2-under-first' },
+      { depth: 1, name: 'h1-second' },
+      { depth: 2, name: 'h2-under-second' }
+    ]
+    expect(treefy(input)).toEqual([
+      {
+        depth: 1,
+        name: 'h1-first',
+        children: [{ depth: 2, name: 'h2-under-first' }]
+      },
+      {
+        depth: 1,
+        name: 'h1-second',
+        children: [{ depth: 2, name: 'h2-under-second' }]
+      }
+    ])
+  })
+
+  it('should strip existing children property from input items', () => {
+    const input = [
+      { depth: 1, name: 'parent', children: 'should be removed' },
+      { depth: 2, name: 'child', children: null }
+    ]
+    expect(treefy(input)).toEqual([
+      {
+        depth: 1,
+        name: 'parent',
+        children: [{ depth: 2, name: 'child' }]
+      }
+    ])
+  })
+
+  // PR #21: treefy bug fix - children were not properly attached to parent nodes
+  it('should correctly attach children to parent (regression test for PR #21)', () => {
+    const input = [
+      { depth: 2, name: 'hogehoge1' },
+      { depth: 3, name: 'fugafuga' },
+      { depth: 2, name: 'hogehoge2' }
+    ]
+    const result = treefy(input)
+
+    // hogehoge1 should have fugafuga as a child
+    expect(result[0].children).toEqual([{ depth: 3, name: 'fugafuga' }])
+    // hogehoge2 should be a separate root node, not nested under hogehoge1
+    expect(result).toHaveLength(2)
+    expect(result[1]).toEqual({ depth: 2, name: 'hogehoge2' })
+  })
+})

--- a/packages/helper/tests/vitest.setup.ts
+++ b/packages/helper/tests/vitest.setup.ts
@@ -1,0 +1,2 @@
+/// <reference types="vitest" />
+import '@testing-library/jest-dom'

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -47,7 +47,7 @@
     "@sakura-ui/core": "^0.4.0-beta.0"
   },
   "dependencies": {
-    "@sakura-ui/helper": "0.0.7",
+    "@sakura-ui/helper": "0.0.8",
     "github-slugger": "^2.0.0",
     "hastscript": "^9.0.0",
     "mdast-util-directive": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.1(react@19.2.1)
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.8(@types/node@24.1.0)(happy-dom@18.0.1)(lightningcss@1.30.2)
 
   packages/markdown:
     dependencies:
@@ -277,8 +280,8 @@ importers:
         specifier: ^0.4.0-beta.0
         version: 0.4.0-beta.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17)
       '@sakura-ui/helper':
-        specifier: 0.0.6
-        version: 0.0.6
+        specifier: 0.0.7
+        version: 0.0.7
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -918,6 +921,9 @@ packages:
 
   '@sakura-ui/helper@0.0.6':
     resolution: {integrity: sha512-Mbr/aYak1azyP4tE/tbvPMCVmg0decAbGTHpS7qxYwgL+dptnxHIZxVJ5h26U46vdFz4UBcJx3afYkP6r2GA1A==}
+
+  '@sakura-ui/helper@0.0.7':
+    resolution: {integrity: sha512-Ns+OG6YDtBJa/gJJSFMDCosnUTJm0DUYdLVnIYw086vV3WkTw687R+RVnoWPqhZnucbmQoo/i5aVYHIm5l5whA==}
 
   '@swc/core-darwin-arm64@1.15.3':
     resolution: {integrity: sha512-AXfeQn0CvcQ4cndlIshETx6jrAM45oeUrK8YeEY6oUZU/qzz0Id0CyvlEywxkWVC81Ajpd8TQQ1fW5yx6zQWkQ==}
@@ -1715,12 +1721,6 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
-
-  magic-string@0.30.15:
-    resolution: {integrity: sha512-zXeaYRgZ6ldS1RJJUrMrYgNJ4fdwnyI6tVqoiIhyCyv5IVTK9BU8Ic2l253GGETQHxI4HNUwhJ3fjDhKqEoaAw==}
-
-  magic-string@0.30.17:
-    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2769,6 +2769,8 @@ snapshots:
 
   '@sakura-ui/helper@0.0.6': {}
 
+  '@sakura-ui/helper@0.0.7': {}
+
   '@swc/core-darwin-arm64@1.15.3':
     optional: true
 
@@ -3010,7 +3012,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.19(@types/node@24.1.0)(lightningcss@1.30.2)
 
@@ -3026,7 +3028,7 @@ snapshots:
   '@vitest/snapshot@2.1.8':
     dependencies:
       '@vitest/pretty-format': 2.1.8
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 1.1.2
 
   '@vitest/spy@2.1.8':
@@ -3548,14 +3550,6 @@ snapshots:
   lru-cache@11.1.0: {}
 
   lz-string@1.5.0: {}
-
-  magic-string@0.30.15:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
-
-  magic-string@0.30.17:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
 
   magic-string@0.30.21:
     dependencies:
@@ -4472,7 +4466,7 @@ snapshots:
       chai: 5.1.2
       debug: 4.4.0
       expect-type: 1.1.0
-      magic-string: 0.30.15
+      magic-string: 0.30.21
       pathe: 1.1.2
       std-env: 3.8.0
       tinybench: 2.9.0


### PR DESCRIPTION
## Summary
- Add unit tests for the `@sakura-ui/helper` package, which previously had zero test coverage
- Cover all utility modules: `mod`, `cx`, `treefy`, and `focusableSelector`
- Include a regression test for the `treefy` bug fixed in PR #21 (`??` → `??=`), ensuring children are correctly attached to parent nodes

## Changes
- **`packages/helper/tests/calc.test.ts`** — 4 tests for the always-positive modulo function (`mod`)
- **`packages/helper/tests/cx.test.ts`** — 5 tests for the class name utility (`cx`), including falsy value filtering and conditional class names
- **`packages/helper/tests/treefy.test.ts`** — 7 tests for the flat-to-tree converter (`treefy`), including empty input, deep nesting, multiple roots, `children` property stripping, and PR #21 regression
- **`packages/helper/tests/querySelector.test.ts`** — 4 tests verifying `focusableSelector` contains expected CSS selectors
- **`packages/helper/tests/vitest.setup.ts`** — Test setup file (imports `@testing-library/jest-dom`)
- **`packages/helper/package.json`** — Add `"type": "module"` and `vitest` dev dependency to enable test execution; bump version to 0.0.8

## Test plan
- [x] `pnpm test` in `packages/helper` — 4 files, 20 tests all passing