### PR TITLE
fix: make the published manifests pass provenance verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/glassonion1/sakura-ui",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:glassonion1/sakura-ui.git"
+    "url": "git+https://github.com/glassonion1/sakura-ui.git"
   },
   "license": "MIT",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/glassonion1/sakura-ui",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:glassonion1/sakura-ui.git",
+    "url": "git+https://github.com/glassonion1/sakura-ui.git",
     "directory": "packages/core"
   },
   "license": "MIT",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/glassonion1/sakura-ui",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:glassonion1/sakura-ui.git",
+    "url": "git+https://github.com/glassonion1/sakura-ui.git",
     "directory": "packages/forms"
   },
   "license": "MIT",

--- a/packages/helper/package.json
+++ b/packages/helper/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@sakura-ui/helper",
   "version": "0.0.9",
+  "author": "glassonion1",
+  "homepage": "https://github.com/glassonion1/sakura-ui",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/glassonion1/sakura-ui.git",
+    "directory": "packages/helper"
+  },
   "license": "MIT",
   "type": "module",
   "main": "dist/index.cjs.js",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/glassonion1/sakura-ui",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:glassonion1/sakura-ui.git",
+    "url": "git+https://github.com/glassonion1/sakura-ui.git",
     "directory": "packages/markdown"
   },
   "license": "MIT",

--- a/packages/tailwind-theme-plugin/package.json
+++ b/packages/tailwind-theme-plugin/package.json
@@ -7,8 +7,8 @@
   "homepage": "https://github.com/glassonion1/sakura-ui",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:glassonion1/sakura-ui.git",
-    "directory": "packages/config"
+    "url": "git+https://github.com/glassonion1/sakura-ui.git",
+    "directory": "packages/tailwind-theme-plugin"
   },
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

The first real publish run failed with a 422 from npm:

```
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/glassonion1/sakura-ui" from provenance
```

Trusted publishing attaches a sigstore provenance bundle, and npm verifies that each manifest's `repository.url` matches the repository the build came from. Three things stood in the way:

- **`@sakura-ui/helper` had no `repository` field at all** — the direct cause of the 422. `homepage` and `author` are added alongside it, matching the other packages.
- **Every URL used the `git+ssh://git@github.com:...` form.** Provenance compares against `https://github.com/glassonion1/sakura-ui`, so all of them now use `git+https://github.com/glassonion1/sakura-ui.git`.
- **`tailwind-theme-plugin` pointed `directory` at `packages/config`**, a leftover from an older layout. It now points at its real path.

Nothing reached npm: the run stopped on the first package, so every version on the registry is untouched (helper 0.0.8, core 0.4.0, forms 0.4.0, markdown 0.2.1, tailwind-theme-plugin 0.4.0, sakura-ui 0.3.0).

A dry run cannot catch this — it never performs the PUT, so provenance is never verified. The failure could only surface on a real publish.

## Verification

```
pnpm lint     # 397 files, no errors
pnpm build    # 6/6
pnpm test     # 9 tasks
```

`pnpm pack` on `@sakura-ui/helper` confirms the published manifest now carries:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/glassonion1/sakura-ui.git",
  "directory": "packages/helper"
}
```

After merging, re-run the Publish workflow manually with the dry run **unchecked** — the release tag 0.4.1 already exists, so no new release is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)