### PR TITLE
fix: correct what the form controls expose to assistive technology

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ export default App
 - LabelControl
 - FieldsetControl
 
+Every form control takes its accessible name from the label it is associated with, so wrap it in `LabelControl` — or `FieldsetControl` for a group of radios or checkboxes. A control rendered without a label has no name for assistive technology.
+
+```tsx
+<LabelControl labelText="添付書類" isRequired>
+  <FileInput />
+</LabelControl>
+```
+
+If a visible label is not an option, pass `aria-label` yourself; it is forwarded to the underlying element.
+
 ## Markdwon extension
 - Markdown
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/sakura-ui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "keywords": [],
   "author": "glassonion1",
   "homepage": "https://github.com/glassonion1/sakura-ui",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/forms",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "keywords": [],
   "author": "glassonion1",

--- a/packages/forms/src/components/Checkbox.tsx
+++ b/packages/forms/src/components/Checkbox.tsx
@@ -68,7 +68,6 @@ export const Checkbox = (props: Checkbox.Props) => {
           aria-describedby={ctx.helperTextId}
           aria-errormessage={ctx.errorMessageId}
           aria-invalid={ctx.isInvalid ?? false}
-          aria-required={ctx.isRequired ?? false}
           {...restProps}
         />
         <span className={cx(styleCheck, iconStyles[size])}>

--- a/packages/forms/src/components/FileInput.tsx
+++ b/packages/forms/src/components/FileInput.tsx
@@ -81,12 +81,10 @@ export const FileInput = (props: FileInput.Props) => {
     `
   }
 
-  // TODO: aria-required is not valid on input[type=file] and role="button" does not
-  // describe a file picker. Both need to be reworked (the required attribute changes
-  // form submission behaviour), so they are tracked separately from this change.
+  // The accessible name comes from the associated label (LabelControl, or a label
+  // supplied by the caller). Do not set aria-label here: it would override that name
+  // and every file input on a page would announce the same thing.
   return (
-    // biome-ignore lint/a11y/useAriaPropsSupportedByRole: see the TODO above
-    // biome-ignore lint/a11y/useSemanticElements: see the TODO above
     <input
       type="file"
       id={id || ctx.id}
@@ -94,9 +92,6 @@ export const FileInput = (props: FileInput.Props) => {
       aria-describedby={ctx.helperTextId}
       aria-errormessage={ctx.errorMessageId}
       aria-invalid={ctx.isInvalid ?? false}
-      aria-required={ctx.isRequired ?? false}
-      role="button"
-      aria-label="File Upload"
       {...restProps}
     />
   )

--- a/packages/forms/src/components/Input.tsx
+++ b/packages/forms/src/components/Input.tsx
@@ -32,7 +32,6 @@ export const Input = (props: Input.Props) => {
       aria-describedby={ctx.helperTextId}
       aria-errormessage={ctx.errorMessageId}
       aria-invalid={ctx.isInvalid ?? false}
-      aria-required={ctx.isRequired ?? false}
       {...restProps}
     />
   )

--- a/packages/forms/src/components/Radio.tsx
+++ b/packages/forms/src/components/Radio.tsx
@@ -59,8 +59,6 @@ export const Radio = (props: Radio.Props) => {
       )}
     >
       <span className="flex items-center">
-        {/* TODO: aria-required belongs on the radiogroup (FieldsetControl), not on each radio */}
-        {/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: see the TODO above */}
         <input
           id={radioId}
           className={styleInput}
@@ -68,7 +66,6 @@ export const Radio = (props: Radio.Props) => {
           aria-describedby={ctx.helperTextId}
           aria-errormessage={ctx.errorMessageId}
           aria-invalid={ctx.isInvalid ?? false}
-          aria-required={ctx.isRequired ?? false}
           {...restProps}
         />
         <span

--- a/packages/forms/src/components/Select.tsx
+++ b/packages/forms/src/components/Select.tsx
@@ -50,7 +50,6 @@ export const Select = (props: Select.Props) => {
         aria-describedby={ctx.helperTextId}
         aria-errormessage={ctx.errorMessageId}
         aria-invalid={ctx.isInvalid ?? false}
-        aria-required={ctx.isRequired ?? false}
         {...restProps}
       >
         {children}

--- a/packages/forms/src/components/Textarea.tsx
+++ b/packages/forms/src/components/Textarea.tsx
@@ -47,7 +47,6 @@ export const Textarea = (props: Textarea.Props) => {
         aria-describedby={ctx.helperTextId}
         aria-errormessage={ctx.errorMessageId}
         aria-invalid={ctx.isInvalid ?? false}
-        aria-required={ctx.isRequired ?? false}
         onChange={onChangeHandler}
         {...restProps}
       >

--- a/packages/forms/tests/FileInput.test.tsx
+++ b/packages/forms/tests/FileInput.test.tsx
@@ -2,17 +2,42 @@ import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
-import { FileInput } from '../src'
+import { FileInput, LabelControl } from '../src'
 
 describe('FileInput', () => {
-  it('should render a file input with a label text', async () => {
-    render(<FileInput />)
+  it('should render a file input', async () => {
+    // input[type=file] maps to no ARIA role, so it cannot be queried by role
+    const { container } = render(<FileInput />)
 
-    const input = screen.getByRole('button')
+    const input = container.querySelector('input[type="file"]')
 
     expect(input).toBeInTheDocument()
+  })
 
-    expect(screen.getByLabelText('File Upload')).toBeInTheDocument()
+  it('should take its accessible name from the surrounding label', async () => {
+    render(
+      <LabelControl labelText="添付書類">
+        <FileInput />
+      </LabelControl>
+    )
+
+    const input = screen.getByLabelText('添付書類')
+
+    expect(input).toBeInTheDocument()
+    // Asserting the accessible name rather than using getByLabelText alone:
+    // getByLabelText also matches aria-label, so it would still pass if the
+    // component set a generic name of its own and shadowed the label.
+    expect(input).toHaveAccessibleName('添付書類')
+  })
+
+  it('should be required when the label control marks it as required', async () => {
+    render(
+      <LabelControl labelText="添付書類" isRequired>
+        <FileInput />
+      </LabelControl>
+    )
+
+    expect(screen.getByLabelText(/添付書類/)).toBeRequired()
   })
 
   it('should pass an object to the ref property', async () => {


### PR DESCRIPTION
## Summary

biome flagged `aria-required` on `FileInput` and `Radio` as unsupported for those elements. Looking into it turned up something heavier underneath.

### `FileInput` announced the wrong name

`FileInput` carried `aria-label="File Upload"`. In accessible name computation `aria-label` outranks an associated `<label>`, so this:

```tsx
<LabelControl labelText="添付書類">
  <FileInput />
</LabelControl>
```

announced **"File Upload, button"** — the label was silently discarded, and every file input on a page said the same thing. `role="button"` compounded it by replacing the native semantics of `input[type=file]` (button plus the name of the selected file), so the chosen filename stopped being announced.

Both attributes date to `d01d0b5 improve unit tests` (2024-12-20), added in the same commit that created `FileInput.test.tsx` so the test could reach the element with `getByRole('button')` and `getByLabelText('File Upload')`. They were never an implementation requirement. Both are removed; the accessible name now comes from the associated label, and callers who render without one can pass their own `aria-label` (it forwards through `restProps`).

### `aria-required` removed everywhere

`Input`, `Textarea`, `Select`, `Checkbox`, `Radio` and `FileInput` all already do:

```tsx
if (ctx.isRequired) {
  restProps.required = true
}
```

so `aria-required` was redundant — and on `Radio` (role=radio) and `FileInput` (no role) it is not a valid attribute at all. Required state is now expressed solely through the `required` attribute. No behaviour changes.

## Why the tests did not catch this

`getByLabelText` matches `aria-label` as well as `<label for>`, so `LabelControl.test.tsx` kept passing while the real accessible name was wrong. The rewritten test asserts the name itself:

```tsx
expect(input).toHaveAccessibleName('添付書類')
```

Verified by temporarily restoring `aria-label` — the test fails with *"Expected element to have accessible name: 添付書類"*. It will catch a regression now.

## Not in scope

Giving `FieldsetControl` `role="radiogroup"` plus `aria-required` was considered and rejected: the same component wraps checkbox groups, where that role would be wrong. A radio group's required state already works through the `required` attribute (HTML applies it per group) and the asterisk in the legend.

## Verification

```
pnpm lint    # 419 files, no errors, and the biome-ignore comments are gone
pnpm build   # 6/6
pnpm test    # forms now 30 tests (28 + 2 new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)