### PR TITLE
fix: rebuild Card and LinkCard, and remove the ARIA and microdata that described the wrong thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ $ pnpm add @sakura-ui/core @sakura-ui/forms @sakura-ui/tailwind-theme-plugin @sa
 $ pnpm add @sakura-ui/core@0.3.1 @sakura-ui/forms@0.2.2 @sakura-ui/tailwind-theme-plugin@0.2.2 @sakura-ui/markdown@0.0.17
 ```
 
+### For the Card API before 0.5.0
+`Card` and `LinkCard` changed shape in `@sakura-ui/core` 0.5.0. See
+[Card and LinkCard](#card-and-linkcard) for what to change; to stay on the old API for now:
+```
+$ pnpm add @sakura-ui/core@0.4.1 @sakura-ui/markdown@0.2.2
+```
+
 ## Configuration
 tailwind.config.js
 ```ts
@@ -103,6 +110,40 @@ export default App
 - Link
 - Card
 - LinkCard
+
+### Card and LinkCard
+`CardHeader` needs an `as` property. There is no default: the right level depends on the
+document outline around the card, and a wrong guess breaks heading navigation. Use `p` for
+lists of many cards, where headings would only add noise.
+
+```tsx
+<Card>
+  <CardHeader as="h3">Title</CardHeader>
+  <CardBody>Body</CardBody>
+</Card>
+```
+
+`LinkCard` puts the link in the title, and the link covers the whole card. Because of that a
+link card cannot contain another link, a button or a form control.
+
+```tsx
+<LinkCard>
+  <LinkCardHeader as="h3" href="/readme">Title</LinkCardHeader>
+  <CardBody>Body</CardBody>
+  <LinkCardFooter>June 27th, 2026</LinkCardFooter>
+</LinkCard>
+```
+
+`Card` renders a `div` and carries no ARIA of its own, so nothing can dangle or collide. A
+`div` maps to the generic role, which cannot take an accessible name. When a card really is a
+self-contained composition, name it yourself:
+
+```tsx
+<Card as="article" aria-labelledby="card-title">
+  <CardHeader as="h3" id="card-title">Title</CardHeader>
+  <CardBody>Body</CardBody>
+</Card>
+```
 - Ol
 - Ul
 - Table

--- a/README.md
+++ b/README.md
@@ -182,6 +182,42 @@ If a visible label is not an option, pass `aria-label` yourself; it is forwarded
 ## Markdwon extension
 - Markdown
 
+## Accessible names
+
+A note for anyone working on these components, rather than for people using them.
+
+Whether an element can be named at all is decided by its role, not by the attribute
+you write. Every ARIA role declares where its name may come from:
+
+| Name from | Meaning | Roles |
+|---|---|---|
+| author, contents | `aria-label`, `aria-labelledby`, **or the text inside** | `button`, `link`, `heading`, `cell`, `option`, `tab`, `menuitem` |
+| author | `aria-label`, `aria-labelledby` or `title` **only** | `article`, `region`, `dialog`, `img`, `table`, `form` |
+| prohibited | cannot be named; the attribute is ignored | `generic` (a bare `<div>` or `<span>`), `paragraph` |
+
+Two consequences catch people out.
+
+**A `<div>` cannot be given a name.** It maps to `generic`, where naming is prohibited,
+so `<div aria-label="Card">` does nothing at all. Reaching for a name means reaching for
+a different element, which is why dropping `aria-labelledby` from `Card` and dropping its
+`<article>` were the same decision.
+
+**An `<article>` does not take its name from a heading inside it.** It is named by the
+author only, so `<article><h3>Title</h3></article>` has no accessible name. A `<button>`
+or an `<a>` would be named "Title" here, because those are named from their contents.
+Mixing the two up is what made `LinkCard` produce a link with no name: an `<a>` wrapping
+an `<article>` never reached the title, because Chrome does not descend into a role that
+is named by its author.
+
+So, in practice:
+
+- Leave it a `<div>` and give it no name. A list and the headings inside it already tell
+  the reader where they are.
+- Use `<section>` only with a name. A `<section>` becomes a `region` **because** it has one;
+  without a name it is no different from a `<div>`.
+- Use `<article>` only for something that stands on its own, and name it when you do.
+  Naming it is recommended by the APG so that readers can tell one article from the next.
+
 ## Development
 
 ### Setup

--- a/examples/src/pages/Home.tsx
+++ b/examples/src/pages/Home.tsx
@@ -269,13 +269,13 @@ const Home = () => {
               <li>
                 <Card>
                   <CardImg src="bg-mt.webp" className="h-48 w-full" />
-                  <CardHeader>Header: XXXxxx</CardHeader>
+                  <CardHeader as="h3">Header: XXXxxx</CardHeader>
                   <CardBody>Body: XXXXXXXXXxxxxxxxxxxxxxxxxxxxxxxxxx</CardBody>
                 </Card>
               </li>
               <li>
                 <Card>
-                  <CardHeader>Header: XXXxxx</CardHeader>
+                  <CardHeader as="h3">Header: XXXxxx</CardHeader>
                   <CardBody>Body: XXXXXXXXXxxxxxxxxxxxxxxxxxxxxxxxxx</CardBody>
                 </Card>
               </li>
@@ -284,13 +284,13 @@ const Home = () => {
           <div className="my-4 grid grid-cols-2 gap-4">
             <Card>
               <CardImg src="bg-mt.webp" className="h-48 w-full" />
-              <CardHeader>Header:XXXxxx</CardHeader>
+              <CardHeader as="h3">Header:XXXxxx</CardHeader>
               <CardBody>Body:XXXXXXXXXXXXxxxxxxxxxxxxx</CardBody>
               <CardFooter>Footer:XXXXXXXXXXXXxxxxxxxxxxxxx</CardFooter>
             </Card>
             <Card>
               <CardImg src="bg-mt.webp" className="h-48 w-full" />
-              <CardHeader>Header:XXXxxx</CardHeader>
+              <CardHeader as="h3">Header:XXXxxx</CardHeader>
               <CardBody>Body:XXXXXXXXXXXXxxxxxxxxxxxxx</CardBody>
               <CardFooter>
                 <Button variant="secondary" className="w-full mb-2">
@@ -305,7 +305,7 @@ const Home = () => {
           <div className="my-4 grid grid-cols-3 gap-4">
             <Card className="">
               <CardImg src="bg-mt.webp" className="h-48 w-full" />
-              <CardHeader>Header:XXXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</CardHeader>
+              <CardHeader as="h3">Header:XXXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</CardHeader>
               <CardBody>
                 Body:XXXXXXXXXXXX
                 <br />
@@ -323,7 +323,7 @@ const Home = () => {
             </Card>
             <Card className="">
               <CardImg src="bg-mt.webp" className="h-48 w-full" />
-              <CardHeader>Header: XXXxxx</CardHeader>
+              <CardHeader as="h3">Header: XXXxxx</CardHeader>
               <CardBody>
                 Body: XXXXXXXXXXXXXXXXXXxxxxxxxxxxxxxxxxxxxxxxxx
               </CardBody>
@@ -335,7 +335,7 @@ const Home = () => {
             </Card>
             <Card className="">
               <CardImg src="bg-mt.webp" className="h-48 w-full" />
-              <CardHeader>Header: XXXxxx</CardHeader>
+              <CardHeader as="h3">Header: XXXxxx</CardHeader>
               <CardBody>
                 Body: XXXXXXXXXXXXXXXXXXxxxxxxxxxxxxxxxxxxxxxxxx
               </CardBody>
@@ -345,23 +345,23 @@ const Home = () => {
             <H2 className="mb-4">Link Card</H2>
             <ul className="flex flex-col gap-4">
               <li>
-                <LinkCard href="/">
-                  <LinkCardHeader>xxxXXX</LinkCardHeader>
+                <LinkCard>
+                  <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
                   <CardBody>xxxxxxxxXXX</CardBody>
                   <LinkCardFooter>June 27th, 205</LinkCardFooter>
                 </LinkCard>
               </li>
               <li>
-                <LinkCard href="https://google.com">
-                  <LinkCardHeader>xxxXXX</LinkCardHeader>
+                <LinkCard>
+                  <LinkCardHeader as="h3" href="https://google.com" target="_blank">xxxXXX</LinkCardHeader>
                   <CardBody>xxxxxxxxXXX</CardBody>
                   <LinkCardFooter />
                 </LinkCard>
               </li>
             </ul>
             <div className="my-4 grid grid-cols-3 gap-4">
-              <LinkCard href="/">
-                <LinkCardHeader>xxxXXX</LinkCardHeader>
+              <LinkCard>
+                <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
                 <CardBody>
                   xxxxxxxxXXX
                   <br />
@@ -371,23 +371,23 @@ const Home = () => {
                 </CardBody>
                 <LinkCardFooter>June 27th, 205</LinkCardFooter>
               </LinkCard>
-              <LinkCard href="/">
-                <LinkCardHeader>xxxXXX</LinkCardHeader>
+              <LinkCard>
+                <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
                 <CardBody>xxxxxxxxXXX</CardBody>
                 <LinkCardFooter>June 27th, 205</LinkCardFooter>
               </LinkCard>
-              <LinkCard href="/">
-                <LinkCardHeader>xxxXXX</LinkCardHeader>
+              <LinkCard>
+                <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
                 <CardBody>xxxxxxxxXXX</CardBody>
                 <LinkCardFooter>June 27th, 205</LinkCardFooter>
               </LinkCard>
-              <LinkCard href="/">
-                <LinkCardHeader>xxxXXX</LinkCardHeader>
+              <LinkCard>
+                <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
                 <CardBody>xxxxxxxxXXX</CardBody>
                 <LinkCardFooter>June 27th, 205</LinkCardFooter>
               </LinkCard>
-              <LinkCard href="/">
-                <LinkCardHeader>xxxXXX</LinkCardHeader>
+              <LinkCard>
+                <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
                 <CardBody>
                   xxxxxxxxXXX
                   <br />

--- a/examples/src/pages/Home.tsx
+++ b/examples/src/pages/Home.tsx
@@ -66,9 +66,7 @@ const Home = () => {
       <header className="max-w-[1120px] mx-auto">
         <div className="p-6 xl:px-0 flex items-center justify-between">
           <div className="text-3xl font-bold">
-            <a className="" href="/sakura-ui/">
-              Sakura-UI
-            </a>
+            <a href="/sakura-ui/">Sakura-UI</a>
           </div>
           <nav>
             <ul className="flex sm:gap-8">
@@ -267,9 +265,13 @@ const Home = () => {
                 </Card>
               </li>
               <li>
-                <Card>
+                {/* Card renders a div and carries no ARIA on its own. A card that is
+                    self-contained content, rather than a link to it, says so itself. */}
+                <Card as="article" aria-labelledby="card-1-title">
                   <CardImg src="bg-mt.webp" className="h-48 w-full" />
-                  <CardHeader as="h3">Header: XXXxxx</CardHeader>
+                  <CardHeader as="h3" id="card-1-title">
+                    Header: XXXxxx
+                  </CardHeader>
                   <CardBody>Body: XXXXXXXXXxxxxxxxxxxxxxxxxxxxxxxxxx</CardBody>
                 </Card>
               </li>
@@ -303,9 +305,11 @@ const Home = () => {
             </Card>
           </div>
           <div className="my-4 grid grid-cols-3 gap-4">
-            <Card className="">
+            <Card>
               <CardImg src="bg-mt.webp" className="h-48 w-full" />
-              <CardHeader as="h3">Header:XXXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</CardHeader>
+              <CardHeader as="h3">
+                Header:XXXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+              </CardHeader>
               <CardBody>
                 Body:XXXXXXXXXXXX
                 <br />
@@ -321,7 +325,7 @@ const Home = () => {
                 </Button>
               </CardFooter>
             </Card>
-            <Card className="">
+            <Card>
               <CardImg src="bg-mt.webp" className="h-48 w-full" />
               <CardHeader as="h3">Header: XXXxxx</CardHeader>
               <CardBody>
@@ -333,7 +337,7 @@ const Home = () => {
                 </Button>
               </CardFooter>
             </Card>
-            <Card className="">
+            <Card>
               <CardImg src="bg-mt.webp" className="h-48 w-full" />
               <CardHeader as="h3">Header: XXXxxx</CardHeader>
               <CardBody>
@@ -346,14 +350,22 @@ const Home = () => {
             <ul className="flex flex-col gap-4">
               <li>
                 <LinkCard>
-                  <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
+                  <LinkCardHeader as="h3" href="/">
+                    xxxXXX
+                  </LinkCardHeader>
                   <CardBody>xxxxxxxxXXX</CardBody>
                   <LinkCardFooter>June 27th, 205</LinkCardFooter>
                 </LinkCard>
               </li>
               <li>
                 <LinkCard>
-                  <LinkCardHeader as="h3" href="https://google.com" target="_blank">xxxXXX</LinkCardHeader>
+                  <LinkCardHeader
+                    as="h3"
+                    href="https://google.com"
+                    target="_blank"
+                  >
+                    xxxXXX
+                  </LinkCardHeader>
                   <CardBody>xxxxxxxxXXX</CardBody>
                   <LinkCardFooter />
                 </LinkCard>
@@ -361,7 +373,9 @@ const Home = () => {
             </ul>
             <div className="my-4 grid grid-cols-3 gap-4">
               <LinkCard>
-                <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
+                <LinkCardHeader as="h3" href="/">
+                  xxxXXX
+                </LinkCardHeader>
                 <CardBody>
                   xxxxxxxxXXX
                   <br />
@@ -372,22 +386,30 @@ const Home = () => {
                 <LinkCardFooter>June 27th, 205</LinkCardFooter>
               </LinkCard>
               <LinkCard>
-                <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
+                <LinkCardHeader as="h3" href="/">
+                  xxxXXX
+                </LinkCardHeader>
                 <CardBody>xxxxxxxxXXX</CardBody>
                 <LinkCardFooter>June 27th, 205</LinkCardFooter>
               </LinkCard>
               <LinkCard>
-                <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
+                <LinkCardHeader as="h3" href="/">
+                  xxxXXX
+                </LinkCardHeader>
                 <CardBody>xxxxxxxxXXX</CardBody>
                 <LinkCardFooter>June 27th, 205</LinkCardFooter>
               </LinkCard>
               <LinkCard>
-                <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
+                <LinkCardHeader as="h3" href="/">
+                  xxxXXX
+                </LinkCardHeader>
                 <CardBody>xxxxxxxxXXX</CardBody>
                 <LinkCardFooter>June 27th, 205</LinkCardFooter>
               </LinkCard>
               <LinkCard>
-                <LinkCardHeader as="h3" href="/">xxxXXX</LinkCardHeader>
+                <LinkCardHeader as="h3" href="/">
+                  xxxXXX
+                </LinkCardHeader>
                 <CardBody>
                   xxxxxxxxXXX
                   <br />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/sakura-ui",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "keywords": [],
   "author": "glassonion1",
   "homepage": "https://github.com/glassonion1/sakura-ui",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/core",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "",
   "keywords": [
     "react",

--- a/packages/core/src/components/Card.tsx
+++ b/packages/core/src/components/Card.tsx
@@ -1,21 +1,16 @@
 import React from 'react'
 import { cx } from '@sakura-ui/helper'
 
-interface IdContextType {
-  id: string
-}
-
-const IdContext = React.createContext<IdContextType>({ id: '' })
-
 export namespace Card {
-  export interface Props extends React.ComponentPropsWithoutRef<'article'> {}
+  export interface Props<T extends React.ElementType> {
+    as?: T
+  }
 }
 
-export const Card = (props: Card.Props) => {
-  const { className, children, ...restProps } = props
-
-  const id = React.useId()
-  const ctx: IdContextType = { id: id }
+export const Card = <T extends React.ElementType = 'div'>(
+  props: Card.Props<T> & Omit<React.ComponentProps<T>, keyof Card.Props<T>>
+) => {
+  const { as: Component = 'div', className, children, ...restProps } = props
 
   const style = `
     border
@@ -27,19 +22,18 @@ export const Card = (props: Card.Props) => {
     overflow-hidden
   `
 
+  // No ARIA here on purpose. A div maps to the generic role, which prohibits an
+  // accessible name, so aria-labelledby would be ignored anyway. Callers that
+  // genuinely need a named region pass as="article" together with their own
+  // aria-labelledby and put a matching id on CardHeader.
   return (
-    <IdContext value={ctx}>
-      <article
-        aria-labelledby={ctx.id}
-        aria-describedby={`${ctx.id}-desc`}
-        className={cx(style, className)}
-        {...restProps}
-      >
-        {children}
-      </article>
-    </IdContext>
+    <Component className={cx(style, className)} {...restProps}>
+      {children}
+    </Component>
   )
 }
+
+Card.displayName = 'Card'
 
 export namespace CardImg {
   export interface Props extends React.ComponentPropsWithoutRef<'img'> {}
@@ -57,16 +51,28 @@ export const CardImg = (props: CardImg.Props) => {
   return <img className={cx(style, className)} {...restProps} />
 }
 
+CardImg.displayName = 'CardImg'
+
+export type CardHeaderAs = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p'
+
 export namespace CardHeader {
-  export interface Props extends React.ComponentPropsWithoutRef<'div'> {}
+  export interface Props extends React.ComponentPropsWithoutRef<'h3'> {
+    /**
+     * The element to render the title as. Required on purpose: the right level
+     * depends on the surrounding document outline, so the library must not pick
+     * one. Use 'p' for lists of many cards, where headings would add noise.
+     */
+    as: CardHeaderAs
+  }
 }
 
 export const CardHeader = (props: CardHeader.Props) => {
-  const { className, children, ...restProps } = props
+  const { as: Component, className, children, ...restProps } = props
 
-  const ctx = React.useContext(IdContext)
-
+  // Reset the browser defaults of the heading and paragraph elements so that the
+  // rendered element does not change how the card looks.
   const style = `
+    m-0
     text-base
     leading-[2rem]
     font-medium
@@ -77,11 +83,13 @@ export const CardHeader = (props: CardHeader.Props) => {
   `
 
   return (
-    <div id={ctx.id} className={cx(style, className)} {...restProps}>
+    <Component className={cx(style, className)} {...restProps}>
       {children}
-    </div>
+    </Component>
   )
 }
+
+CardHeader.displayName = 'CardHeader'
 
 export namespace CardBody {
   export interface Props extends React.ComponentPropsWithoutRef<'div'> {}
@@ -89,8 +97,6 @@ export namespace CardBody {
 
 export const CardBody = (props: CardBody.Props) => {
   const { className, children, ...restProps } = props
-
-  const ctx = React.useContext(IdContext)
 
   const style = `
     text-base-sm
@@ -101,12 +107,16 @@ export const CardBody = (props: CardBody.Props) => {
     px-6
   `
 
+  // No generated id here. Callers that want the body to describe the card pass
+  // their own id and point aria-describedby at it.
   return (
-    <div id={`${ctx.id}-desc`} className={cx(style, className)} {...restProps}>
+    <div className={cx(style, className)} {...restProps}>
       {children}
     </div>
   )
 }
+
+CardBody.displayName = 'CardBody'
 
 export namespace CardFooter {
   export interface Props extends React.ComponentPropsWithoutRef<'div'> {}
@@ -135,3 +145,5 @@ export const CardFooter = (props: CardFooter.Props) => {
     </div>
   )
 }
+
+CardFooter.displayName = 'CardFooter'

--- a/packages/core/src/components/Card.tsx
+++ b/packages/core/src/components/Card.tsx
@@ -69,6 +69,15 @@ export namespace CardHeader {
 export const CardHeader = (props: CardHeader.Props) => {
   const { as: Component, className, children, ...restProps } = props
 
+  if (!Component) {
+    // Without this, React reports an invalid element type and suggests a missing
+    // export, which says nothing about the property that was actually left out.
+    throw new Error(
+      'CardHeader: the "as" property is required. Pass the heading level that ' +
+        'fits the outline around the card, or "p" for lists of many cards.'
+    )
+  }
+
   // Reset the browser defaults of the heading and paragraph elements so that the
   // rendered element does not change how the card looks.
   const style = `

--- a/packages/core/src/components/Card.tsx
+++ b/packages/core/src/components/Card.tsx
@@ -22,10 +22,8 @@ export const Card = <T extends React.ElementType = 'div'>(
     overflow-hidden
   `
 
-  // No ARIA here on purpose. A div maps to the generic role, which prohibits an
-  // accessible name, so aria-labelledby would be ignored anyway. Callers that
-  // genuinely need a named region pass as="article" together with their own
-  // aria-labelledby and put a matching id on CardHeader.
+  // A div cannot carry an accessible name, so no ARIA is set here. See the
+  // Accessible names section of the README before adding any.
   return (
     <Component className={cx(style, className)} {...restProps}>
       {children}

--- a/packages/core/src/components/Faq.tsx
+++ b/packages/core/src/components/Faq.tsx
@@ -18,11 +18,8 @@ export const Faq = (props: Faq.Props) => {
     flex-col
     gap-8
   `
-  // No schema.org markup here. It put the scope for Question on this list, so a
-  // parser read every pair as one question with several names. Describing the
-  // list correctly would take a component per pair, to hold a scope each.
-  // Google withdrew the FAQ rich result in May 2026, so that work now buys
-  // nothing, and the markup is dropped instead of restructured.
+  // No schema.org FAQPage markup here. Google discontinued the FAQ rich result
+  // in May 2026, so it is not implemented.
   return (
     <dl className={cx(style, className)} {...restProps}>
       {children}

--- a/packages/core/src/components/Faq.tsx
+++ b/packages/core/src/components/Faq.tsx
@@ -18,18 +18,15 @@ export const Faq = (props: Faq.Props) => {
     flex-col
     gap-8
   `
+  // No schema.org markup here. It put the scope for Question on this list, so a
+  // parser read every pair as one question with several names. Describing the
+  // list correctly would take a component per pair, to hold a scope each.
+  // Google withdrew the FAQ rich result in May 2026, so that work now buys
+  // nothing, and the markup is dropped instead of restructured.
   return (
-    <article itemScope itemType="https://schema.org/FAQPage">
-      <dl
-        className={cx(style, className)}
-        itemScope
-        itemProp="mainEntity"
-        itemType="https://schema.org/Question"
-        {...restProps}
-      >
-        {children}
-      </dl>
-    </article>
+    <dl className={cx(style, className)} {...restProps}>
+      {children}
+    </dl>
   )
 }
 
@@ -47,11 +44,7 @@ export const Question = (props: Question.Props) => {
     mt-8
   `
   return (
-    <dt
-      className={cx(style, headingStyle, className)}
-      itemProp="name"
-      {...restProps}
-    >
+    <dt className={cx(style, headingStyle, className)} {...restProps}>
       <span aria-hidden="true">Q</span>
       <span>{children}</span>
     </dt>
@@ -72,17 +65,11 @@ export const Answer = (props: Answer.Props) => {
     gap-8
   `
   return (
-    <dd
-      className={cx(style, className)}
-      itemScope
-      itemProp="acceptedAnswer"
-      itemType="https://schema.org/Answer"
-      {...restProps}
-    >
+    <dd className={cx(style, className)} {...restProps}>
       <span className={cx(headingStyle, '!leading-none')} aria-hidden="true">
         A
       </span>
-      <span itemProp="text">{children}</span>
+      <span>{children}</span>
     </dd>
   )
 }

--- a/packages/core/src/components/LinkCard.tsx
+++ b/packages/core/src/components/LinkCard.tsx
@@ -90,6 +90,13 @@ export const LinkCardHeader = <T extends React.ElementType = 'a'>(
     ...restProps
   } = props
 
+  if (!as) {
+    throw new Error(
+      'LinkCardHeader: the "as" property is required. Pass the heading level ' +
+        'that fits the outline around the card, or "p" for lists of many cards.'
+    )
+  }
+
   const styleHeading = `
     decoration-blue-900
     underline

--- a/packages/core/src/components/LinkCard.tsx
+++ b/packages/core/src/components/LinkCard.tsx
@@ -34,9 +34,10 @@ export const LinkCard = <T extends React.ElementType = 'div'>(
     hover:bg-solid-gray-50
   `
 
-  // The focus ring is drawn on the card itself rather than on the <a>, so that it
-  // surrounds the whole card. An element's own outline is not clipped by its own
-  // overflow-hidden, which the ::after overlay inside it would be.
+  // The focus ring goes on the card itself, not on the <a>, so that it surrounds
+  // the whole card. The card sets overflow-hidden, which would cut off a ring
+  // drawn on the ::after overlay inside it. An element never clips its own
+  // outline, so the ring survives here.
   const styleFocus = `
     has-[a:focus-visible]:outline
     has-[a:focus-visible]:outline-4

--- a/packages/core/src/components/LinkCard.tsx
+++ b/packages/core/src/components/LinkCard.tsx
@@ -1,98 +1,137 @@
 import React from 'react'
-import { cx, Style } from '@sakura-ui/helper'
-import { Card, CardFooter, CardHeader } from './Card'
+import { cx } from '@sakura-ui/helper'
+import { Card, CardFooter, CardHeader, type CardHeaderAs } from './Card'
 import { Icon } from './Icon'
 
 export namespace LinkCard {
-  export interface Props<T extends React.ElementType>
-    extends React.ComponentProps<'article'> {
-    href: string
-    target?: string
-    linkAs?: T
-  }
+  export interface Props<T extends React.ElementType> extends Card.Props<T> {}
 }
 
-export const LinkCard = <T extends React.ElementType = 'a'>(
-  props: LinkCard.Props<T>
+/**
+ * A Card whose title carries the link. The link stretches over the whole card
+ * through a ::after overlay, so the card cannot contain another link, a button
+ * or a form control.
+ */
+export const LinkCard = <T extends React.ElementType = 'div'>(
+  props: LinkCard.Props<T> & Omit<React.ComponentProps<T>, keyof LinkCard.Props<T>>
 ) => {
-  const {
-    href,
-    target,
-    linkAs: Component = 'a',
-    className,
-    children,
-    ...rest
-  } = props
+  const { className, children, ...restProps } = props
 
-  const styleLink = `
-    grid
-    outline-offset-4
-    rounded-2xl
-    sm:rounded-3xl
-    w-full h-full
-    ${Style.focusCard}
+  // z-0 establishes a stacking context so that the overlay of the title can be
+  // raised above the rest of the card. CardFooter is sticky, which makes it a
+  // positioned element that would otherwise paint over the overlay and swallow
+  // the clicks aimed at the bottom of the card.
+  const stylePosition = `
+    relative
+    z-0
     group
   `
 
   const styleHover = `
-    group-hover:outline
-    group-hover:outline-blue-900
-    group-hover:outline-4
-    group-hover:outline-offset-[-1px]
+    hover:outline
+    hover:outline-2
+    hover:outline-black
+    hover:bg-solid-gray-50
   `
 
+  // The focus ring is drawn on the card itself rather than on the <a>, so that it
+  // surrounds the whole card. An element's own outline is not clipped by its own
+  // overflow-hidden, which the ::after overlay inside it would be.
+  const styleFocus = `
+    has-[a:focus-visible]:outline
+    has-[a:focus-visible]:outline-4
+    has-[a:focus-visible]:outline-black
+    has-[a:focus-visible]:outline-offset-[calc(2/16*1rem)]
+    has-[a:focus-visible]:ring-[calc(2/16*1rem)]
+    has-[a:focus-visible]:ring-yellow-300
+  `
+
+  // TypeScript cannot carry the generic through to Card, which is polymorphic in
+  // the same way. The public signature above stays exact; only this hand-off is
+  // widened.
+  const Root = Card as React.ElementType
+
   return (
-    <Component className={cx(styleLink)} href={href} target={target}>
-      <Card className={cx(styleHover, className)} {...rest}>
-        {children}
-      </Card>
-    </Component>
+    <Root
+      className={cx(stylePosition, styleHover, styleFocus, className)}
+      {...restProps}
+    >
+      {children}
+    </Root>
   )
 }
 
+LinkCard.displayName = 'LinkCard'
+
 export namespace LinkCardHeader {
-  export interface Props extends React.ComponentProps<'div'> {
-    target?: string
+  export interface Props<T extends React.ElementType> {
+    /** The element to render the title as. See CardHeader. */
+    as: CardHeaderAs
+    /** The component to render the link as. Defaults to an anchor element. */
+    linkAs?: T
   }
 }
 
-export const LinkCardHeader = ({
-  target,
-  className,
-  children
-}: LinkCardHeader.Props) => {
+/**
+ * The title of a LinkCard, holding the link that covers the whole card.
+ *
+ * `className` styles the title element; every other prop (href, target, and
+ * whatever the component passed to `linkAs` accepts) goes to the link.
+ */
+export const LinkCardHeader = <T extends React.ElementType = 'a'>(
+  props: LinkCardHeader.Props<T> &
+    Omit<React.ComponentProps<T>, keyof LinkCardHeader.Props<T>>
+) => {
+  const {
+    as,
+    linkAs: Component = 'a',
+    className,
+    children,
+    ...restProps
+  } = props
+
   const styleHeading = `
     decoration-blue-900
     underline
     underline-offset-[calc(3/16*1rem)]
-  `
-  const styleHover = `
+   
     group-hover:text-blue-900
     group-hover:decoration-[calc(3/16*1rem)]
   `
 
+  // The ::after overlay makes the whole card clickable. It carries no visual of
+  // its own; the focus ring lives on the LinkCard element.
+  const styleOverlay = `
+    after:content-['']
+    after:absolute
+    after:inset-0
+    after:z-10
+    focus-visible:outline-none
+  `
+
   return (
-    <CardHeader className={cx(className, styleHeading, styleHover)}>
-      <span>
+    <CardHeader as={as} className={cx(className, styleHeading)}>
+      <Component className={styleOverlay} {...restProps}>
         {children}
-        {target === '_blank' && (
-          <Icon opticalSize={16} className="ml-1">
+        {restProps.target === '_blank' && (
+          <Icon opticalSize={16} className="ml-1" altText="新しいタブで開きます">
             open_in_new
           </Icon>
         )}
-      </span>
+      </Component>
     </CardHeader>
   )
 }
 
+LinkCardHeader.displayName = 'LinkCardHeader'
+
 export namespace LinkCardFooter {
-  export interface Props extends React.ComponentProps<'div'> {}
+  export interface Props extends React.ComponentPropsWithoutRef<'div'> {}
 }
 
-export const LinkCardFooter = ({
-  className,
-  children
-}: LinkCardFooter.Props) => {
+export const LinkCardFooter = (props: LinkCardFooter.Props) => {
+  const { className, children, ...restProps } = props
+
   const style = `
     flex
     justify-between
@@ -116,7 +155,7 @@ export const LinkCardFooter = ({
   `
 
   return (
-    <CardFooter className={cx(className, style)}>
+    <CardFooter className={cx(style, className)} {...restProps}>
       <span>{children}</span>
       <span className={cx(styleIcon, styleIconHover)}>
         <Icon opticalSize={16}>arrow_forward</Icon>
@@ -124,3 +163,5 @@ export const LinkCardFooter = ({
     </CardFooter>
   )
 }
+
+LinkCardFooter.displayName = 'LinkCardFooter'

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -1,6 +1,7 @@
 export { Button } from './Button'
 export { MenuButton } from './MenuButton'
 export { Card, CardImg, CardHeader, CardBody, CardFooter } from './Card'
+export type { CardHeaderAs } from './Card'
 export { LinkCard, LinkCardHeader, LinkCardFooter } from './LinkCard'
 export { Code } from './Code'
 export { Faq, Question, Answer } from './Faq'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,3 +38,5 @@ export {
   PopoverMenu,
   PopoverMenuItem
 } from './components'
+
+export type { CardHeaderAs } from './components'

--- a/packages/core/tests/Card.test.tsx
+++ b/packages/core/tests/Card.test.tsx
@@ -2,46 +2,134 @@ import React from 'react'
 import { describe, expect, it } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
-import { Card, CardBody, CardHeader } from '../src'
+import { Card, CardBody, CardFooter, CardHeader } from '../src'
 
 describe('Card', () => {
-  it('should labeled text from Card', async () => {
+  it('should render its header and body', async () => {
     render(
       <Card>
-        <CardHeader>Card-Header</CardHeader>
+        <CardHeader as="h3">Card-Header</CardHeader>
         <CardBody>Card-Body</CardBody>
       </Card>
     )
 
-    const text1 = screen.getByText(/Card-Header/)
-    expect(text1).toBeInTheDocument()
-
-    const text2 = screen.getByText(/Card-Body/)
-    expect(text2).toBeInTheDocument()
+    expect(screen.getByText('Card-Header')).toBeInTheDocument()
+    expect(screen.getByText('Card-Body')).toBeInTheDocument()
   })
-  it('should set the role and id correctly', async () => {
+
+  it('should render the header as the element given by the as property', async () => {
     render(
       <Card>
-        <CardHeader data-testid="header">Card-Header</CardHeader>
+        <CardHeader as="h4">Card-Header</CardHeader>
+      </Card>
+    )
+
+    // Querying by role rather than by tag name: the point of the change is that
+    // the title is reachable by heading navigation, not that it is an <h4>.
+    expect(
+      screen.getByRole('heading', { level: 4, name: 'Card-Header' })
+    ).toBeInTheDocument()
+  })
+
+  it('should render the header as a paragraph when asked to', async () => {
+    render(
+      <Card>
+        <CardHeader as="p">Card-Header</CardHeader>
+      </Card>
+    )
+
+    // Lists of many cards use 'p' so that the headings do not pollute the outline.
+    expect(screen.queryByRole('heading')).toBeNull()
+    expect(screen.getByText('Card-Header')).toBeInTheDocument()
+  })
+
+  it('should render the root as the element given by the as property', async () => {
+    render(
+      <Card as="article">
+        <CardHeader as="h3">Card-Header</CardHeader>
+      </Card>
+    )
+
+    expect(screen.getByRole('article')).toBeInTheDocument()
+  })
+
+  it('should not generate any id or aria reference of its own', async () => {
+    const { container } = render(
+      <Card as="article">
+        <CardHeader as="h3" data-testid="header">
+          Card-Header
+        </CardHeader>
         <CardBody data-testid="body">Card-Body</CardBody>
       </Card>
     )
 
     const card = screen.getByRole('article')
-    expect(card).toBeInTheDocument()
+    // A generated id can only ever dangle or collide, so the library emits none.
+    // Callers that want the card named do it themselves, see the test below.
+    expect(card).not.toHaveAttribute('aria-labelledby')
+    expect(card).not.toHaveAttribute('aria-describedby')
+    expect(screen.getByTestId('header')).not.toHaveAttribute('id')
+    expect(screen.getByTestId('body')).not.toHaveAttribute('id')
+    expect(container.querySelector('[id=""]')).toBeNull()
+  })
 
-    const header = screen.getByTestId('header')
-    expect(header).toBeInTheDocument()
-    expect(header).toHaveAttribute('id')
+  it('should not repeat an id when more than one body is rendered', async () => {
+    render(
+      <Card>
+        <CardBody data-testid="body1">Body-1</CardBody>
+        <CardBody data-testid="body2">Body-2</CardBody>
+      </Card>
+    )
 
-    const headerText = screen.getByLabelText('Card-Header')
-    expect(headerText).toBeInTheDocument()
+    expect(screen.getByTestId('body1')).not.toHaveAttribute('id')
+    expect(screen.getByTestId('body2')).not.toHaveAttribute('id')
+  })
 
-    const body = screen.getByTestId('body')
-    expect(body).toBeInTheDocument()
-    expect(body).toHaveAttribute('id')
+  it('should let the caller name the card explicitly', async () => {
+    render(
+      <Card as="article" aria-labelledby="card-title" aria-describedby="card-desc">
+        <CardHeader as="h3" id="card-title">
+          Card-Header
+        </CardHeader>
+        <CardBody id="card-desc">Card-Body</CardBody>
+      </Card>
+    )
 
-    const bodyText = screen.getByRole('article', { description: 'Card-Body' })
-    expect(bodyText).toBeInTheDocument()
+    const card = screen.getByRole('article')
+    expect(card).toHaveAccessibleName('Card-Header')
+    expect(card).toHaveAccessibleDescription('Card-Body')
+  })
+
+  it('should render a card without a header', async () => {
+    render(
+      <Card as="article">
+        <CardBody>Card-Body</CardBody>
+      </Card>
+    )
+
+    // Used to leave aria-labelledby pointing at an element that was never rendered.
+    const card = screen.getByRole('article')
+    expect(card).not.toHaveAttribute('aria-labelledby')
+    expect(card).toHaveAccessibleName('')
+  })
+
+  it('should pass unknown properties through to the elements', async () => {
+    render(
+      <Card>
+        <CardHeader as="h3" data-testid="header" data-kind="title">
+          Card-Header
+        </CardHeader>
+        <CardBody data-testid="body" data-kind="desc">
+          Card-Body
+        </CardBody>
+        <CardFooter data-testid="footer" data-kind="meta">
+          Card-Footer
+        </CardFooter>
+      </Card>
+    )
+
+    expect(screen.getByTestId('header')).toHaveAttribute('data-kind', 'title')
+    expect(screen.getByTestId('body')).toHaveAttribute('data-kind', 'desc')
+    expect(screen.getByTestId('footer')).toHaveAttribute('data-kind', 'meta')
   })
 })

--- a/packages/core/tests/Card.test.tsx
+++ b/packages/core/tests/Card.test.tsx
@@ -113,6 +113,22 @@ describe('Card', () => {
     expect(card).toHaveAccessibleName('')
   })
 
+  it('should say which property is missing when as is left out', async () => {
+    // React would otherwise report an invalid element type and suggest a missing
+    // export, which points nowhere near the actual mistake.
+    const Header = CardHeader as unknown as React.ComponentType<{
+      children: React.ReactNode
+    }>
+
+    expect(() =>
+      render(
+        <Card>
+          <Header>Card-Header</Header>
+        </Card>
+      )
+    ).toThrow(/CardHeader: the "as" property is required/)
+  })
+
   it('should pass unknown properties through to the elements', async () => {
     render(
       <Card>

--- a/packages/core/tests/Faq.test.tsx
+++ b/packages/core/tests/Faq.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { Answer, Faq, Question } from '../src'
+
+describe('Faq', () => {
+  it('should render the questions and the answers', async () => {
+    render(
+      <Faq>
+        <Question>Question-1</Question>
+        <Answer>Answer-1</Answer>
+        <Question>Question-2</Question>
+        <Answer>Answer-2</Answer>
+      </Faq>
+    )
+
+    expect(screen.getByText('Question-1')).toBeInTheDocument()
+    expect(screen.getByText('Answer-1')).toBeInTheDocument()
+    expect(screen.getByText('Question-2')).toBeInTheDocument()
+    expect(screen.getByText('Answer-2')).toBeInTheDocument()
+  })
+
+  it('should keep the Q and A markers out of the accessibility tree', async () => {
+    render(
+      <Faq>
+        <Question data-testid="question">Question-1</Question>
+        <Answer>Answer-1</Answer>
+      </Faq>
+    )
+
+    // The letters are there for the eye only; a reader gets the question text.
+    const marker = screen.getByTestId('question').firstElementChild
+    expect(marker).toHaveTextContent('Q')
+    expect(marker).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('should render a plain definition list', async () => {
+    const { container } = render(
+      <Faq>
+        <Question>Question-1</Question>
+        <Answer>Answer-1</Answer>
+        <Question>Question-2</Question>
+        <Answer>Answer-2</Answer>
+      </Faq>
+    )
+
+    // The schema.org markup described the whole list as one Question carrying a
+    // name and an answer per pair, and it wrapped everything in an article that
+    // nothing could name. Both are gone.
+    expect(container.querySelector('[itemscope]')).toBeNull()
+    expect(container.querySelector('[itemprop]')).toBeNull()
+    expect(container.querySelector('article')).toBeNull()
+    expect(container.querySelector('dl')).toBeInTheDocument()
+    expect(container.querySelectorAll('dt')).toHaveLength(2)
+    expect(container.querySelectorAll('dd')).toHaveLength(2)
+  })
+
+  it('should pass unknown properties through to the elements', async () => {
+    render(
+      <Faq data-testid="faq" data-kind="list">
+        <Question data-testid="question" data-kind="q">
+          Question-1
+        </Question>
+        <Answer data-testid="answer" data-kind="a">
+          Answer-1
+        </Answer>
+      </Faq>
+    )
+
+    expect(screen.getByTestId('faq')).toHaveAttribute('data-kind', 'list')
+    expect(screen.getByTestId('question')).toHaveAttribute('data-kind', 'q')
+    expect(screen.getByTestId('answer')).toHaveAttribute('data-kind', 'a')
+  })
+})

--- a/packages/core/tests/LinkCard.test.tsx
+++ b/packages/core/tests/LinkCard.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { CardBody, LinkCard, LinkCardFooter, LinkCardHeader } from '../src'
+
+describe('LinkCard', () => {
+  it('should render the title as a link', async () => {
+    render(
+      <LinkCard>
+        <LinkCardHeader as="h3" href="/readme">
+          Link-Card-Header
+        </LinkCardHeader>
+        <CardBody>Link-Card-Body</CardBody>
+      </LinkCard>
+    )
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/readme')
+  })
+
+  it('should take the accessible name of the link from the title alone', async () => {
+    render(
+      <LinkCard>
+        <LinkCardHeader as="h3" href="/readme">
+          Link-Card-Header
+        </LinkCardHeader>
+        <CardBody>Link-Card-Body</CardBody>
+        <LinkCardFooter>June 27th, 2026</LinkCardFooter>
+      </LinkCard>
+    )
+
+    // Asserting the accessible name rather than the link text: when the anchor
+    // wrapped the whole card, the body and the footer were read out as part of
+    // the link name before it was announced as a link.
+    const link = screen.getByRole('link')
+    expect(link).toHaveAccessibleName('Link-Card-Header')
+    expect(link).not.toHaveAccessibleName(/Link-Card-Body/)
+  })
+
+  it('should keep the title reachable by heading navigation', async () => {
+    render(
+      <LinkCard>
+        <LinkCardHeader as="h3" href="/readme">
+          Link-Card-Header
+        </LinkCardHeader>
+      </LinkCard>
+    )
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Link-Card-Header' })
+    ).toBeInTheDocument()
+  })
+
+  it('should tell that the link opens in a new tab', async () => {
+    render(
+      <LinkCard>
+        <LinkCardHeader as="h3" href="https://example.com" target="_blank">
+          Link-Card-Header
+        </LinkCardHeader>
+      </LinkCard>
+    )
+
+    // The icon itself is aria-hidden, so without the alternative text the fact
+    // that the link opens elsewhere reached sighted users only.
+    expect(screen.getByRole('link')).toHaveAccessibleName(
+      /新しいタブで開きます/
+    )
+  })
+
+  it('should not tell about a new tab for a link that stays in the tab', async () => {
+    render(
+      <LinkCard>
+        <LinkCardHeader as="h3" href="/readme">
+          Link-Card-Header
+        </LinkCardHeader>
+      </LinkCard>
+    )
+
+    expect(screen.getByRole('link')).toHaveAccessibleName('Link-Card-Header')
+  })
+
+  it('should render the link with the component given by linkAs', async () => {
+    const NextLinkLike = ({
+      to,
+      children,
+      ...rest
+    }: { to: string; children: React.ReactNode }) => (
+      <a href={to} {...rest}>
+        {children}
+      </a>
+    )
+
+    render(
+      <LinkCard>
+        <LinkCardHeader as="h3" linkAs={NextLinkLike} to="/readme">
+          Link-Card-Header
+        </LinkCardHeader>
+      </LinkCard>
+    )
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/readme')
+  })
+
+  it('should pass unknown properties through to the link and the footer', async () => {
+    render(
+      <LinkCard data-testid="card">
+        <LinkCardHeader as="h3" href="/readme" data-kind="title">
+          Link-Card-Header
+        </LinkCardHeader>
+        <LinkCardFooter data-testid="footer" data-kind="meta">
+          June 27th, 2026
+        </LinkCardFooter>
+      </LinkCard>
+    )
+
+    // These used to be dropped: both components declared that they accept the
+    // properties of a div but never spread them onto an element.
+    expect(screen.getByRole('link')).toHaveAttribute('data-kind', 'title')
+    expect(screen.getByTestId('footer')).toHaveAttribute('data-kind', 'meta')
+    expect(screen.getByTestId('card')).toBeInTheDocument()
+  })
+
+  it('should pass an object to the ref property', async () => {
+    const ref = vi.fn()
+    render(
+      <LinkCard ref={ref}>
+        <LinkCardHeader as="h3" href="/readme">
+          Link-Card-Header
+        </LinkCardHeader>
+      </LinkCard>
+    )
+
+    expect(ref).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/tests/LinkCard.test.tsx
+++ b/packages/core/tests/LinkCard.test.tsx
@@ -121,6 +121,21 @@ describe('LinkCard', () => {
     expect(screen.getByTestId('card')).toBeInTheDocument()
   })
 
+  it('should say which property is missing when as is left out', async () => {
+    const Header = LinkCardHeader as unknown as React.ComponentType<{
+      href: string
+      children: React.ReactNode
+    }>
+
+    expect(() =>
+      render(
+        <LinkCard>
+          <Header href="/readme">Link-Card-Header</Header>
+        </LinkCard>
+      )
+    ).toThrow(/LinkCardHeader: the "as" property is required/)
+  })
+
   it('should pass an object to the ref property', async () => {
     const ref = vi.fn()
     render(

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -68,6 +68,7 @@
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
+    "@sakura-ui/core": "workspace:*",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
     "@types/mdast": "^4.0.4",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/markdown",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "",
   "keywords": [
     "markdown"
@@ -42,7 +42,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@sakura-ui/core": "^0.4.0-beta.0",
+    "@sakura-ui/core": "^0.5.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "tailwindcss": "^4.1.17"

--- a/packages/markdown/src/components/Markdown.tsx
+++ b/packages/markdown/src/components/Markdown.tsx
@@ -38,10 +38,13 @@ import {
   Button,
   Card,
   CardImg,
+  CardHeader,
   CardBody,
   CardFooter,
   LinkCard,
   LinkCardHeader,
+  LinkCardFooter,
+  type CardHeaderAs,
   OverflowContainer
 } from '@sakura-ui/core'
 import {
@@ -125,14 +128,9 @@ const Article = (props: ArticleProps) => {
   const node = restProps['data-node']
 
   if (node === 'card') {
+    // The href now lives on the title, which is what carries the link.
     if (restProps['data-behavior'] === 'link') {
-      const href = restProps['data-href'] as string
-
-      return (
-        <LinkCard href={href} className={cx(className)}>
-          {children}
-        </LinkCard>
-      )
+      return <LinkCard className={cx(className)}>{children}</LinkCard>
     }
     return <Card className={cx(className)}>{children}</Card>
   }
@@ -144,20 +142,36 @@ const Article = (props: ArticleProps) => {
   )
 }
 
-interface DivProps extends React.ComponentPropsWithoutRef<'div'>, DataProps {}
+interface DivProps extends React.ComponentPropsWithoutRef<'div'>, DataProps {
+  headingLevel?: CardHeaderAs
+}
 
 const Div = (props: DivProps) => {
-  const { children, ...restProps } = props
+  const { children, headingLevel = 'h3', ...restProps } = props
 
   const node = restProps['data-node']
+  const isLink = restProps['data-behavior'] === 'link'
 
   if (node === 'card-title') {
-    return <LinkCardHeader>{children}</LinkCardHeader>
+    if (isLink) {
+      return (
+        <LinkCardHeader
+          as={headingLevel}
+          href={restProps['data-href'] as string}
+        >
+          {children}
+        </LinkCardHeader>
+      )
+    }
+    return <CardHeader as={headingLevel}>{children}</CardHeader>
   }
   if (node === 'card-description') {
     return <CardBody>{children}</CardBody>
   }
   if (node === 'card-footer') {
+    if (isLink) {
+      return <LinkCardFooter>{children}</LinkCardFooter>
+    }
     return <CardFooter>{children}</CardFooter>
   }
 
@@ -264,6 +278,14 @@ export const Markdown = ({
 
   const markdown2ReactElements = React.useCallback(
     (md: string) => {
+      // Card titles sit in the body of the document, so h3 is the natural base.
+      // rehype-shift-heading cannot reach them because they are still divs when
+      // it runs, so the same shift is applied here.
+      const cardHeadingLevel = `h${Math.min(
+        6,
+        Math.max(1, 3 + shiftHeding)
+      )}` as CardHeaderAs
+
       const rhypeReactOptions = {
         ...production,
         components: {
@@ -292,7 +314,9 @@ export const Markdown = ({
           th: Th,
           tr: Tr,
           td: Td,
-          div: Div
+          div: (props: DivProps) => (
+            <Div {...props} headingLevel={cardHeadingLevel} />
+          )
         }
       }
 

--- a/packages/markdown/src/plugins/card.ts
+++ b/packages/markdown/src/plugins/card.ts
@@ -33,6 +33,9 @@ export const cardPlugin = () => {
 
       node.data.hProperties = h(tagName, node.attributes).properties
 
+      const attributes = node.attributes
+      const isLink = attributes['data-behavior'] === 'link'
+
       node.children.forEach((child) => {
         if (!isDirective(child)) {
           return
@@ -49,6 +52,17 @@ export const cardPlugin = () => {
 
         child.attributes = child.attributes ?? {}
         child.attributes['data-node'] = child.name
+
+        // The title carries the link, so it needs the href of the card. The
+        // footer only needs to know that it belongs to a link card, to render
+        // the arrow. A child cannot read its parent once this is a React tree,
+        // so the marker is copied down here.
+        if (isLink && (child.name === 'card-title' || child.name === 'card-footer')) {
+          child.attributes['data-behavior'] = 'link'
+          if (child.name === 'card-title') {
+            child.attributes['data-href'] = attributes['data-href'] || ''
+          }
+        }
 
         child.data.hProperties = h(tagName, child.attributes).properties
       })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,9 +273,6 @@ importers:
 
   packages/markdown:
     dependencies:
-      '@sakura-ui/core':
-        specifier: ^0.4.0-beta.0
-        version: 0.4.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)
       '@sakura-ui/helper':
         specifier: workspace:*
         version: link:../helper
@@ -331,6 +328,9 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
     devDependencies:
+      '@sakura-ui/core':
+        specifier: workspace:*
+        version: link:../core
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 7.0.1(@testing-library/dom@10.4.1)(vitest@4.1.11(@types/node@24.13.3)(happy-dom@20.11.6)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)))
@@ -794,16 +794,6 @@ packages:
     resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
     cpu: [x64]
     os: [win32]
-
-  '@sakura-ui/core@0.4.0':
-    resolution: {integrity: sha512-VvG/zRcK7JxtiU1BMaK5EB7wRgtgH9Mi/6BQexCInpLrh9LM2eFnaWbtdrXQ3R0+PJJluvSuwnR+yaNTFNizNw==}
-    peerDependencies:
-      react: ^19.2.1
-      react-dom: ^19.2.1
-      tailwindcss: ^4.1.17
-
-  '@sakura-ui/helper@0.0.6':
-    resolution: {integrity: sha512-Mbr/aYak1azyP4tE/tbvPMCVmg0decAbGTHpS7qxYwgL+dptnxHIZxVJ5h26U46vdFz4UBcJx3afYkP6r2GA1A==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2438,15 +2428,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
-
-  '@sakura-ui/core@0.4.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)':
-    dependencies:
-      '@sakura-ui/helper': 0.0.6
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      tailwindcss: 4.3.3
-
-  '@sakura-ui/helper@0.0.6': {}
 
   '@standard-schema/spec@1.1.0': {}
 


### PR DESCRIPTION
Three components stopped describing themselves accurately to assistive technology, in three different ways. This branch fixes all three, and writes down the rule they all turned on.

- **`Card` / `LinkCard`** — a link card could produce a link with no accessible name; the ids behind it could dangle, collide, or render empty
- **`Faq`** — schema.org markup that parsed a list of questions as a single question, wrapped in an `<article>` nothing could name
- **README** — an *Accessible names* section, so the next person does not have to rediscover why

## Why

`LinkCard` could produce a link with no accessible name. The anchor wrapped the `<article>`, and Chrome does not descend into roles whose name comes from the author when it computes a name from content, so a card without `LinkCardHeader` gave the link an empty name — WCAG 2.4.4 and 4.1.2. That corner of the accname spec is still undefined ([w3c/accname#7](https://github.com/w3c/accname/issues/7), [#226](https://github.com/w3c/accname/issues/226)), so the behaviour also differs between engines. Even when a name was computed, it ran the title, the body and the footer together before announcing the link.

The ARIA wiring around it had grown by accretion rather than by design:

| | |
|---|---|
| ~2023-08-10 | `CardHeader` was an `<h2>` that generated its own id |
| `f452bcd` | the id moved into `Card` and was shared through a context, so that `<article aria-labelledby>` could work |
| `38ab533` | the heading dropped to a `<div>`, as part of a styling change |
| `c562d3a` | `aria-describedby` was added on top |

`Card` generated one id and handed it to `CardHeader` and `CardBody` through a context, which only holds together while both are there:

- leave out `CardHeader`, and `aria-labelledby` points at an element that was never rendered
- use two `CardBody`, and the same id lands on both, which HTML does not allow
- use `CardHeader` outside a `Card`, and the default of the context, an empty string, renders as `id=""`, which HTML does not allow either

The first of those was live: a card rendered without a `CardBody` still pointed `aria-describedby` at one.

Alongside that, `LinkCardHeader` and `LinkCardFooter` declared that they accept the properties of a div but dropped them, the icon for a link that opens in a new tab had no alternative text, and `@sakura-ui/markdown` paired the wrong components — a plain card got `LinkCardHeader`, which underlines a title that cannot be clicked, and a link card got `CardFooter`, which loses the arrow.

## Card and LinkCard

`Card` renders a `div` and carries no ARIA of its own, so none of the id problems can happen: a `div` maps to the generic role, which cannot take an accessible name anyway. Callers that need a named region pass `as="article"` with their own `aria-labelledby`, which is what the [DADS example components](https://github.com/digital-go-jp/design-system-example-components-react) do as well.

`CardHeader` is a heading again, with a required `as`. There is no default because the right level depends on the outline around the card, and `'p'` is allowed for lists of many cards, following the DADS `ResourceList`. Both header components now throw with the name of the property when it is left out — React would otherwise report an invalid element type and suggest a forgotten export, which points nowhere near the mistake. A default was deliberately not added: `38ab533` shows what happens when the library decides the heading level for the caller, with the heading sitting at `div` for two years afterwards.

`LinkCard` puts the link in the title and stretches it over the card with an overlay. Because of that a link card cannot contain another link, a button or a form control — the same constraint DADS states for a clickable container. The look does not change: border, radius, title underline, arrow, hover and focus ring all stay where they were. Hover now follows the DADS `ResourceList`, a black outline and a grey background.

The example page shows the shape a named card takes now, once: `as="article"` on the card, `aria-labelledby` pointing at an id on the header. Only once, deliberately — most cards are a link to content rather than the content itself, and a `div` carries no name at all, which is the right default.

## Faq

The itemscope for `Question` sat on the `<dl>`, so a list of pairs parsed as **one** question. Running the rendered markup through a microdata parser gives a single `Question` with `name: ["QQ1", "QQ2"]` and two `acceptedAnswer` values, rather than two questions. The name also swallowed the decorative "Q", because `aria-hidden` keeps a letter out of the accessibility tree but not out of the text a parser reads.

Describing the list correctly would take a component per pair, to hold a scope each. Google withdrew the FAQ rich result from Search on 2026-05-07 and removed its documentation in July, so that work now buys nothing, and the markup is dropped instead of restructured. `FAQPage` is still a valid schema.org type and other crawlers may read it, but there is little reason to carry a description that says something the page does not mean.

The `<article>` that existed to carry the `FAQPage` scope goes with it. Nothing could name it, because `Faq` passes `className` and the rest of its properties to the `<dl>`, so it sat in the accessibility tree as an unnamed article. The list, the markers and the styling are unchanged.

## Accessible names, in the README

Whether an element can carry a name is decided by its role, not by the attribute you write. A `<div>` maps to `generic`, where naming is prohibited, so `aria-label` on it does nothing. An `<article>` is named by the author only, so a heading inside it is not its name — while a `<button>` or an `<a>` is named from its contents. Getting those two the wrong way round is exactly what produced the nameless link, and the same rule decided both the `Card` and the `Faq` change. The section is written for whoever touches these components next, rather than for people using them.

## Breaking changes

`@sakura-ui/core` 0.5.0, `@sakura-ui/markdown` 0.3.0. A `0.x` caret pins the minor, so anything on `^0.4.0` stays where it is until it asks for the new version.

```diff
-<Card>
-  <CardHeader>Title</CardHeader>
+<Card>
+  <CardHeader as="h3">Title</CardHeader>
   <CardBody>Body</CardBody>
 </Card>

-<LinkCard href="/readme">
-  <LinkCardHeader>Title</LinkCardHeader>
+<LinkCard>
+  <LinkCardHeader as="h3" href="/readme">Title</LinkCardHeader>
   <CardBody>Body</CardBody>
   <LinkCardFooter />
 </LinkCard>
```

`Card` no longer renders an `<article>` and no longer sets `aria-labelledby` or `aria-describedby`. To keep a named region:

```tsx
<Card as="article" aria-labelledby="card-title">
  <CardHeader as="h3" id="card-title">Title</CardHeader>
  <CardBody>Body</CardBody>
</Card>
```

`Faq` no longer emits schema.org microdata and no longer wraps the list in an `<article>`.

## Verification

`pnpm lint`, `pnpm build` and `pnpm test` pass. `packages/core/tests/LinkCard.test.tsx` and `packages/core/tests/Faq.test.tsx` are new — neither component had any tests.

The test environment cannot settle this on its own: happy-dom and `dom-accessibility-api` disagree with Chrome exactly where the bug lived. So the examples app was driven in Chrome and the accessibility tree read through CDP:

```
=== link nodes ===
"xxxXXX"                       ← the title alone; no body, no footer
"xxxXXX 新しいタブで開きます"    ← the new-tab icon now has alternative text
=== headings ===
h3: "xxxXXX"                   ← reachable by heading navigation
=== article nodes ===
"Header: XXXxxx"               ← one, and it is named
```

The overlay measures 958×139px over a 960×141px card, and `elementFromPoint` at the bottom-right of the card returns the anchor.

One thing that only showed up there: `CardFooter` is `sticky`, which makes it a positioned element, and it painted over the overlay and took the clicks aimed at the bottom of the card. Removing `after:z-10` makes `elementFromPoint` return the footer `div` instead of the anchor, which is how it was confirmed. DADS handles it the same way, with `z-index: 0` on the card and `1` on the overlay.

## Notes

- `linkAs` was going to be renamed to `as`, but once `href` moved to `LinkCardHeader` that name collided with the heading element. `as` is the heading, `linkAs` is the link component, and the real defect — `Props<T>` never composed `ComponentProps<T>`, so `linkAs={NextLink}` could not accept `prefetch` — is fixed.
- `Card` and `LinkCard` stay separate components rather than merging behind `as`. Once the link moved into the title, the root of a link card is no longer the link, so there is nothing for `as` to switch.
- `packages/markdown` resolved `@sakura-ui/core` to the published 0.4.0, because it only declared it as a peer. Local changes to core were invisible to it. It now also has `workspace:*` in `devDependencies`, matching every other internal reference in this repository.
- `examples/src/pages/Home.tsx` has a type error on `opticalSize`. It is on `main` as well and is left alone.
- H-05, the raw HTML sanitisation of `@sakura-ui/markdown`, is not addressed here. It will be handled when that package leaves unified, rather than by patching a pipeline that is being replaced.

---

# 日本語

3 つのコンポーネントが、それぞれ別の形で、支援技術に対して実態と違う情報を渡していました。このブランチではその 3 つを直し、共通して効いていたルールを文書化します。

- **`Card` / `LinkCard`** — アクセシブルネームが空のリンクを作れてしまう。背後で生成される id は、存在しない要素を指したり、重複したり、空文字になったりする
- **`Faq`** — Q&A の一覧が単一の質問として解釈される schema.org マークアップと、誰も名前を付けられない `<article>`
- **README** — *Accessible names* の節。次に触る人が同じ調査をやり直さなくて済むように

## 背景

`LinkCard` はアクセシブルネームが空のリンクを作れる状態でした。`<a>` が `<article>` を包む構造で、Chrome は name from content の再帰でアクセシブルネームを著者が与えるロールの中に降りないため、`LinkCardHeader` の無いカードではリンク名が空になります（WCAG 2.4.4 / 4.1.2）。この領域は accname 仕様（アクセシブルネームの計算方法を定める W3C 仕様）でまだ未定義（[w3c/accname#7](https://github.com/w3c/accname/issues/7)、[#226](https://github.com/w3c/accname/issues/226)）で、エンジンごとに挙動が割れます。名前が計算される場合も、タイトル・本文・フッタを続けて読み上げてから「リンク」と告げていました。

周辺の ARIA は設計されたものではなく、後から積み重なったものでした。

| | |
|---|---|
| 〜2023-08-10 | `CardHeader` は `<h2>` で、自分で id を生成していた |
| `f452bcd` | `<article aria-labelledby>` を成立させるため、id を `Card` に引き上げて context で配布 |
| `38ab533` | スタイル変更の一環として見出しが `<div>` に降格 |
| `c562d3a` | `aria-describedby` を追加 |

`Card` は id を 1 つ作り、context 経由で `CardHeader` と `CardBody` に配っていました。この仕組みは、両方が揃っているときしか成り立ちません。

- `CardHeader` を省くと、`aria-labelledby` が**描画されていない要素**を指す
- `CardBody` を 2 つ置くと、**同じ id が 2 つの要素に付く**（HTML は id を文書内で一意と定めている）
- `Card` の外で `CardHeader` を使うと、context の既定値が空文字なので **`id=""`** が出力される（HTML は id に 1 文字以上を要求している）

1 つ目は実際に起きていました。`CardBody` を持たないカードが、`aria-describedby` でその存在しない要素を指していました。

あわせて、`LinkCardHeader` と `LinkCardFooter` は div の props を受け付けると型で宣言しながら実際には捨てており、別タブで開くリンクのアイコンには代替テキストが無く、`@sakura-ui/markdown` はコンポーネントの対を間違えていました（plain なカードに `LinkCardHeader` が付いて押せないタイトルに下線が引かれ、リンクカードに `CardFooter` が付いて矢印が欠落）。

## Card と LinkCard

`Card` は `div` を描画し、ARIA を自分では持ちません。`div` は generic ロールでアクセシブルネームを持てないため、そもそも `aria-labelledby` は無視されます。名前の付いた領域が必要な場合は `as="article"` と `aria-labelledby` を利用側が明示します。[DADS の例示コンポーネント](https://github.com/digital-go-jp/design-system-example-components-react)も同じ方針です。

`CardHeader` は再び見出し要素になり、`as` を必須にしました。適切なレベルはカード周辺のアウトライン次第なので既定値を置きません。カードを大量に並べる一覧向けに `'p'` も許可しています（DADS `ResourceList` に準拠）。`as` を省いた場合は両方の Header コンポーネントがプロパティ名を含めて例外を投げます。そのままだと React が「要素の型が不正」「export し忘れでは」と報告し、実際の原因と無関係な案内になるためです。既定値を置かなかったのは意図的で、`38ab533` のようにライブラリ側が見出しレベルを決めると、その後 2 年間 `div` のまま放置されるということが起きます。

`LinkCard` はタイトルにリンクを置き、オーバーレイでカード全面に広げます。そのため、リンクカードの中に別のリンク・ボタン・フォームコントロールは置けません（DADS がクリッカブルなコンテナに課しているのと同じ制約）。**見た目は変わりません** — 枠線・角丸・タイトルの下線・矢印・ホバー・フォーカスリングはそのままです。ホバーのみ DADS `ResourceList` に合わせ、黒のアウトラインとグレー背景にしました。

examples のページには、名前を持たせるカードの書き方を **1 箇所だけ** 反映しました（カードに `as="article"`、`aria-labelledby` が Header の `id` を指す形）。1 箇所なのは意図的で、多くのカードはコンテンツそのものではなくコンテンツへのリンクであり、`div` のまま名前を持たないのが正しい既定だからです。

## Faq

`Question` の itemscope が `<dl>` に付いていたため、Q&A の一覧が **1 つの質問**として解釈されていました。microdata パーサに通すと、2 つの質問ではなく `name: ["QQ1", "QQ2"]` と 2 つの `acceptedAnswer` を持つ単一の `Question` になります。装飾の「Q」が名前に混ざるのは、`aria-hidden` が文字をアクセシビリティツリーから外してもパーサが読むテキストからは外さないためです。

正しく記述するには、スコープを 1 つずつ持たせるためにペアごとのコンポーネントが要ります。Google は 2026-05-07 に FAQ リッチリザルトを Search から取り下げ、7 月にドキュメントも削除したため、その手間に見合う対価がもうありません。よって作り直さず削除しました。`FAQPage` は schema.org の型としては今も有効で他のクローラが読む可能性もありますが、ページの意味と違う記述を抱え続ける理由は薄いと判断しました。

`FAQPage` のスコープを持つためだけに存在していた `<article>` も一緒に消えます。`Faq` は `className` とその他の props を `<dl>` に渡すため誰も名前を付けられず、名前のない article としてアクセシビリティツリーに残っていました。リスト・マーカー・見た目は変わりません。

## README の Accessible names

名前を持てるかどうかは、書いた属性ではなく**その要素のロール**が決めます。`<div>` は `generic` ロールで命名が禁止されているため、`aria-label` を書いても何も起きません。`<article>` は著者からしか名前を得られないため中の見出しは名前になりませんが、`<button>` や `<a>` は中身から名前を得ます。この 2 つを取り違えたことが名前のないリンクを生み、同じルールが `Card` と `Faq` の両方の判断を決めました。この節は利用者向けではなく、次にこれらのコンポーネントを触る人向けです。

## 破壊的変更

`@sakura-ui/core` 0.5.0、`@sakura-ui/markdown` 0.3.0。`0.x` のキャレットはマイナーを固定するため、`^0.4.0` を使っている利用者は明示的に上げるまで影響を受けません。移行は上記の diff のとおりです。`Faq` は schema.org の microdata を出力しなくなり、`<article>` でも包まなくなります。

## 検証

`pnpm lint` / `pnpm build` / `pnpm test` はすべて通ります。`packages/core/tests/LinkCard.test.tsx` と `packages/core/tests/Faq.test.tsx` は新規で、どちらのコンポーネントにもテストがありませんでした。

ただしテスト環境だけでは決着しません。happy-dom と `dom-accessibility-api` は、まさに今回のバグがあった箇所で Chrome と結果が食い違います。そこで examples アプリを Chrome で動かし、CDP でアクセシビリティツリーを読みました（結果は英語側のとおり）。オーバーレイは 960×141px のカードに対して 958×139px を占め、カード右下の `elementFromPoint` は `<a>` を返します。

そこでしか出てこなかった問題が 1 つあります。`CardFooter` は `sticky` で位置指定要素になるため、オーバーレイの上に描かれてカード下部のクリックを奪っていました。`after:z-10` を外すと `elementFromPoint` が `<a>` ではなくフッタの `div` を返すことで確認しています。DADS も同じ対処（カードに `z-index: 0`、オーバーレイに `1`）をしています。

## 補足

- `linkAs` を `as` にリネームする予定でしたが、`href` を `LinkCardHeader` に移した結果、見出し要素の指定と名前が衝突するためやめました。`as` が見出し、`linkAs` がリンクコンポーネントです。本来の不具合（`Props<T>` が `ComponentProps<T>` を合成しておらず、`linkAs={NextLink}` に `prefetch` を渡せない）は修正済みです。
- `Card` と `LinkCard` は `as` で統合せず、別コンポーネントのまま残します。リンクがタイトルの中に移った時点で、リンクカードのルートはもうリンクではなくなり、`as` で切り替える対象が無くなったためです。
- `packages/markdown` は `@sakura-ui/core` を peer でしか宣言しておらず、公開済みの 0.4.0 に解決されていました。ローカルの core の変更が見えない状態だったため、`devDependencies` に `workspace:*` を追加しました（リポジトリ内の他の内部依存と同じ形）。
- `examples/src/pages/Home.tsx` の `opticalSize` の型エラーは `main` にもある既存の問題のため触っていません。
- H-05（`@sakura-ui/markdown` の生 HTML サニタイズ）はこの PR では扱いません。差し替え予定のパイプラインに手を入れるのは捨て仕事になるため、unified から移行する作業で対応します。

