### PR TITLE
fix: repair the Tailwind classes that compiled to nothing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/sakura-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "keywords": [],
   "author": "glassonion1",
   "homepage": "https://github.com/glassonion1/sakura-ui",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "",
   "keywords": [
     "react",

--- a/packages/core/src/components/LangSelector.tsx
+++ b/packages/core/src/components/LangSelector.tsx
@@ -49,8 +49,8 @@ export const LangSelector = ({
   const stylePositionBottomRight = `
     absolute
     top-[anchor(--target_bottom)]
-    right-[anchor(--target_right)] 
-    position-try-options:flip-block]
+    right-[anchor(--target_right)]
+    [position-try-fallbacks:flip-block]
     inset-[unset]
   `
 

--- a/packages/core/src/components/PopoverMenu.tsx
+++ b/packages/core/src/components/PopoverMenu.tsx
@@ -15,7 +15,7 @@ export const PopoverMenu = React.forwardRef<
     shadow-1
     rounded-lg
     border
-    border-solid-grey-420
+    border-solid-gray-420
     has-[>:nth-child(7)]:rounded-r-none
   `
 
@@ -46,7 +46,7 @@ export const PopoverMenuItem = React.forwardRef<
     flex
     items-center
     gap-x-1.5
-    hover:bg-solid-grey-50
+    hover:bg-solid-gray-50
     ${Style.focusRectCondensedWithBg}
   `
 

--- a/packages/core/src/components/PopoverMenu.tsx
+++ b/packages/core/src/components/PopoverMenu.tsx
@@ -7,22 +7,11 @@ export const PopoverMenu = React.forwardRef<
   React.ComponentProps<'ul'>
 >((props, ref) => {
   const { className, children, ...rest } = props
-  const stylePopover = `
-    min-w-fit
-    w-auto
-    py-2
-    bg-white
-    shadow-1
-    rounded-lg
-    border
-    border-solid-gray-420
-    has-[>:nth-child(7)]:rounded-r-none
-  `
 
   const style = `
     font-normal
     whitespace-nowrap
-    ${stylePopover}
+    ${Style.popover}
   `
 
   return (

--- a/packages/core/src/components/Table.tsx
+++ b/packages/core/src/components/Table.tsx
@@ -8,7 +8,7 @@ export namespace Table {
 const styleBorder = `
   border
   border-collapse
-  border-solid-grey-420
+  border-solid-gray-420
 `
 
 export const Table = (props: Table.Props) => {

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/forms",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "",
   "keywords": [],
   "author": "glassonion1",

--- a/packages/helper/package.json
+++ b/packages/helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/helper",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": "glassonion1",
   "homepage": "https://github.com/glassonion1/sakura-ui",
   "repository": {

--- a/packages/helper/src/styles.ts
+++ b/packages/helper/src/styles.ts
@@ -86,18 +86,6 @@ export namespace Style {
     has-[>:nth-child(7)]:rounded-r-none
   `
 
-  export const popoverPositionBottomRight = `
-    absolute
-    top-11
-    right-0
-  `
-
-  export const popoverPositionBottomLeft = `
-    absolute
-    top-11
-    left-0
-  `
-
   export namespace Peer {
     export const focus = `
       peer-focus-visible:outline-4

--- a/packages/helper/src/styles.ts
+++ b/packages/helper/src/styles.ts
@@ -5,7 +5,7 @@ export namespace Style {
     border
     border-transparent
     rounded-lg
-    hover:bg-solid-grey-50
+    hover:bg-solid-gray-50
   `
 
   export const selected = `
@@ -82,7 +82,7 @@ export namespace Style {
     shadow-1
     rounded-lg
     border
-    border-solid-grey-420
+    border-solid-gray-420
     has-[>:nth-child(7)]:rounded-r-none
   `
 

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/markdown",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "keywords": [
     "markdown"

--- a/packages/tailwind-theme-plugin/package.json
+++ b/packages/tailwind-theme-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/tailwind-theme-plugin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "keywords": [],
   "author": "glassonion1",


### PR DESCRIPTION
Three Tailwind classes in this workspace named something the build does not produce, so they compiled to nothing. Two of them were the same misspelling repeated in five places; the third was a malformed arbitrary property. None of them failed loudly — Tailwind drops a class it cannot resolve without a warning, which is why all three sat here unnoticed.

## grey vs gray

`packages/tailwind-theme-plugin` defines the neutral scale as `solid-gray` and `opacity-gray`. Five call sites asked for `solid-grey`:

| file | class |
|---|---|
| `packages/core/src/components/Table.tsx:11` | `border-solid-grey-420` |
| `packages/core/src/components/PopoverMenu.tsx:18` | `border-solid-grey-420` |
| `packages/core/src/components/PopoverMenu.tsx:49` | `hover:bg-solid-grey-50` |
| `packages/helper/src/styles.ts:8` | `hover:bg-solid-grey-50` |
| `packages/helper/src/styles.ts:85` | `border-solid-grey-420` |

The three borders still drew a line, because `border` is a separate class and the colour fell back to `currentColor`. That is why they survived this long. The two hover backgrounds did nothing at all — menu items and clickable rows simply had no hover state.

The built stylesheet now carries:

```css
.border-solid-gray-420{border-color:#949494}
.hover\:bg-solid-gray-50:hover{background-color:#f2f2f2}
```

## The duplicate behind two of them

`PopoverMenu` declared `stylePopover` as a local template, character for character identical to `Style.popover` in `@sakura-ui/helper` — misspelling included. The file already imports `Style` and reads `focusRectCondensedWithBg` and `hoverUnderline` from it, and `Style.popover` had no reader anywhere in the workspace.

That copy is the reason the same typo had to be fixed in two places, and the reason fixing one of them would have left the other broken. `PopoverMenu` now reads `Style.popover`, so the next change to the popover chrome lands once.

## LangSelector's position fallback

`LangSelector` asked for `position-try-options:flip-block]` — no opening bracket, so Tailwind read it as an unknown variant rather than an arbitrary property and emitted nothing. The language menu had no fallback position and stayed below the button even when that put it past the bottom of the viewport.

Repairing the bracket alone would not have been enough. `position-try-options` was renamed to `position-try-fallbacks` and stopped working in Chrome 128 ([syntax changes](https://developer.chrome.com/blog/anchor-syntax-changes)), so the old spelling would have stayed inert. Both are corrected together:

```css
.\[position-try-fallbacks\:flip-block\]{position-try-fallbacks:flip-block}
```

## Breaking change

`Style.popoverPositionBottomRight` and `Style.popoverPositionBottomLeft` are removed from `@sakura-ui/helper`. They positioned the menu with `absolute top-11 right-0`, left over from before `LangSelector` moved to CSS anchor positioning, and nothing in the workspace read either one.

`@sakura-ui/helper` is on `0.0.x`, where semver promises nothing, and every package that depends on it is published pinning an exact version, so no installed tree picks this up on its own.

## Versions

Every package takes a patch bump.

| package | | why |
|---|---|---|
| `core` | 0.5.0 → 0.5.1 | source changed |
| `helper` | 0.0.9 → 0.0.10 | source changed |
| `forms` | 0.4.2 → 0.4.3 | republished against the new `helper` |
| `markdown` | 0.3.0 → 0.3.1 | republished against the new `helper` |
| `tailwind-theme-plugin` | 0.4.1 → 0.4.2 | unchanged, bumped to keep the set together |

`forms` and `markdown` have no source change, but pnpm rewrites their `workspace:*` dependency on `helper` to an exact version at publish time — the published `forms@0.4.2` and `markdown@0.3.0` both ask for `helper@0.0.9`, so their users would never have seen the fix. `markdown` takes `core` through a `^0.5.0` peer range and would have followed on its own.

## Verification

`pnpm build`, `pnpm test` and `pnpm lint` all pass, and no `grey` remains in the repository.

More to the point, each fix is checked against the generated stylesheet rather than against the source. The whole class of bug here is a class name that compiles to nothing, so the source proves little: the four rules quoted above were grepped out of `examples/dist/assets/*.css` after the build.

No tests are added. These are class-name strings with no behaviour to assert, and a test that snapshots a `className` would have passed just as happily on the misspelling. The build output is what tells the truth here.

# 日本語

このワークスペースの Tailwind クラス 3 種類が、ビルドの生成しない名前を指していたため CSS を 1 行も出していませんでした。2 つは同じスペルミスが 5 箇所、もう 1 つは壊れた任意プロパティです。いずれもエラーにはなりません。Tailwind は解決できないクラスを警告なく捨てるため、3 つとも気づかれずに残っていました。

## grey と gray

`packages/tailwind-theme-plugin` が定義しているニュートラル系は `solid-gray` と `opacity-gray` だけです。呼び出し側 5 箇所が `solid-grey` を指していました（表は英語側のとおり）。

ボーダー 3 箇所は線自体は出ていました。`border` が別クラスで、色が `currentColor` にフォールバックしていたためです。これが長く残った理由です。一方、ホバー背景の 2 箇所は完全に無反応で、メニュー項目とクリッカブル行にホバー状態がありませんでした。

## 2 箇所に増えていた原因

`PopoverMenu` はローカルに `stylePopover` を宣言していましたが、その中身は `@sakura-ui/helper` の `Style.popover` と 1 文字違わず同一で、スペルミスまで同じでした。同ファイルはすでに `Style` を import して `focusRectCondensedWithBg` と `hoverUnderline` を使っており、`Style.popover` の方はワークスペース内に参照が 1 件もない状態でした。

同じタイポを 2 箇所直す羽目になったのはこの複製が原因であり、片方だけ直していればもう片方は壊れたまま残っていました。`Style.popover` を参照する形に寄せ、次にポップオーバーの見た目を変える時は 1 箇所で済むようにしています。

## LangSelector のフォールバック位置

`LangSelector` は `position-try-options:flip-block]` を指定していました。開き括弧が無いため、Tailwind は任意プロパティではなく未知のバリアントとして解釈し、何も出力していません。言語メニューはフォールバック位置を持たず、ビューポート下端をはみ出す場合でもボタンの下に出たままでした。

括弧を直すだけでは不十分です。`position-try-options` は `position-try-fallbacks` に改名され、Chrome 128 で旧名は動作しなくなっています（[syntax changes](https://developer.chrome.com/blog/anchor-syntax-changes)）。両方まとめて修正しました。

## 破壊的変更

`@sakura-ui/helper` から `Style.popoverPositionBottomRight` と `Style.popoverPositionBottomLeft` を削除しました。`absolute top-11 right-0` でメニューを配置する、`LangSelector` が CSS anchor positioning に移行する前の遺物で、ワークスペース内に参照はありませんでした。

`@sakura-ui/helper` は `0.0.x` で semver 上の互換保証がなく、依存している各パッケージは公開時に厳密バージョンで固定されているため、既存の install が勝手にこれを拾って壊れることはありません。

## バージョン

全パッケージのパッチを上げています（表は英語側のとおり）。

`forms` と `markdown` はソース無変更ですが、pnpm は publish 時に `workspace:*` を厳密バージョンへ書き換えます。公開済みの `forms@0.4.2` と `markdown@0.3.0` はどちらも `helper@0.0.9` を要求しており、そのままでは利用者に修正が届きません。`markdown` の `core` 依存は `^0.5.0` の peer なので、そちらは放っておいても追随します。

## 検証

`pnpm build` / `pnpm test` / `pnpm lint` はすべて通り、リポジトリ内に `grey` は残っていません。

より重要な点として、各修正はソースではなく**生成された CSS** に対して確認しています。今回のバグはいずれも「クラス名が間違っていて何も生成されない」種類のため、ソースを見ても何も保証できません。上に引用した 4 つのルールは、ビルド後の `examples/dist/assets/*.css` から実際に grep して取り出したものです。

テストは追加していません。対象がクラス名の文字列で、表明すべき挙動がないためです。`className` をスナップショットするテストを書いたとしても、スペルミスのままで同じように通ってしまいます。ここで真実を語るのはビルド成果物の方です。
