### PR TITLE
fix: give the table of contents its own heading back

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/sakura-ui",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "keywords": [],
   "author": "glassonion1",
   "homepage": "https://github.com/glassonion1/sakura-ui",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/markdown",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "keywords": [
     "markdown"

--- a/packages/markdown/src/components/Markdown.tsx
+++ b/packages/markdown/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import { H2, Link, Ul } from '@sakura-ui/core'
+import { Link, Ul } from '@sakura-ui/core'
 import React from 'react'
 import { type HeadingItem, render, type RenderResult } from '../render'
 
@@ -74,7 +74,15 @@ export const Markdown = ({
     <div className="py-8 flex flex-col gap-8">
       {showToc && headings.length > 0 && (
         <nav className="rounded-3xl p-10 bg-yellow-50">
-          <H2 className="pt-0">{tocTitle}</H2>
+          {/*
+            A plain h2 rather than core's H2. That one is built for a heading in
+            a document: it is sized to be read as one, and carries the space
+            that separates it from the text above it. This is the label on a
+            box, at the top of it, with nothing above to separate it from.
+          */}
+          <h2 className="mb-4 font-bold text-h-xs-m sm:text-h-xs">
+            {tocTitle}
+          </h2>
           <Ul>
             <TableOfContents items={headings} />
           </Ul>

--- a/packages/markdown/tests/__snapshots__/Markdown.test.tsx.snap
+++ b/packages/markdown/tests/__snapshots__/Markdown.test.tsx.snap
@@ -269,12 +269,7 @@ exports[`Markdown > raw html > should render tableSpan 1`] = `
 `;
 
 exports[`Markdown > table of contents > should render the table of contents when asked for it 1`] = `
-"<div class="py-8 flex flex-col gap-8"><nav class="rounded-3xl p-10 bg-yellow-50"><h2 class="
-    text-h-med-m
-    sm:text-h-med
-    pt-[4rem]
-    sm:pt-[4.5rem]
-   pt-0">目次</h2><ul class="
+"<div class="py-8 flex flex-col gap-8"><nav class="rounded-3xl p-10 bg-yellow-50"><h2 class="mb-4 font-bold text-h-xs-m sm:text-h-xs">目次</h2><ul class="
   list-disc
   [&amp;_&amp;]:list-circle
   [&amp;_&amp;_&amp;]:list-square


### PR DESCRIPTION
The table of contents heading sits at the top of its box, with the box's own padding above it and nothing else.

```diff
-<H2 className="pt-0">{tocTitle}</H2>
+<h2 className="mb-4 font-bold text-h-xs-m sm:text-h-xs">{tocTitle}</h2>
```

It reads at `text-h-xs`, the size of a label rather than of a heading in the document.

Measured on a rendered page:

| width | padding above the heading |
|---|---|
| 375px | 104px → 40px |
| 1280px | 112px → 40px |

## Cause

Core's `H2` is built for a heading in a document: it is sized to be read as one, and carries `pt-[4rem] sm:pt-[4.5rem]` to separate it from the text above. `pt-0` was passed to cancel that and could not — the class strings are joined rather than merged, so all three reach the element and the `sm` variant wins from `sm` up.

The label on a box does not need either, so it does not use `H2`.

## Elsewhere in the package

`Link` and `Ul` in the table of contents are the only core components left, and neither carries document spacing. The article body uses the class strings from `styles` and no components at all.

## Version

`@sakura-ui/markdown` 0.4.1, root 0.5.3. `pnpm lint`, `pnpm build`, `pnpm test` pass; 90 tests.

---

# 日本語

目次の見出しが箱の上端に付き、その上には箱自身の padding だけが残ります。

```diff
-<H2 className="pt-0">{tocTitle}</H2>
+<h2 className="mb-4 font-bold text-h-xs-m sm:text-h-xs">{tocTitle}</h2>
```

大きさは `text-h-xs` になります。文書中の見出しではなくラベルの大きさです。

描画されたページでの実測値:

| 幅 | 見出しの上の余白 |
|---|---|
| 375px | 104px → 40px |
| 1280px | 112px → 40px |

## 原因

core の `H2` は文書中の見出しのために作られており、見出しとして読まれる大きさを持ち、上のテキストと隔てるための `pt-[4rem] sm:pt-[4.5rem]` を持ちます。これを `pt-0` で打ち消そうとしていましたが、効きません。クラス文字列は結合されるだけで統合されないため、3 つとも要素に届き、`sm` 以上では variant が勝ちます。

箱のラベルにはどちらも要らないため、`H2` を使いません。

## パッケージ内の他の箇所

目次の `Link` と `Ul` が残る唯一の core コンポーネントで、どちらも文書用の余白を持ち込みません。記事本文は `styles` のクラス文字列だけを使い、コンポーネントは使いません。

## バージョン

`@sakura-ui/markdown` 0.4.1、root 0.5.3。`pnpm lint` / `pnpm build` / `pnpm test` が通ります（テスト 90 件）。
