### PR TITLE
fix: put the spacing back between the blocks of a document

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/sakura-ui",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "keywords": [],
   "author": "glassonion1",
   "homepage": "https://github.com/glassonion1/sakura-ui",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/markdown",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "keywords": [
     "markdown"

--- a/packages/markdown/src/components/Markdown.tsx
+++ b/packages/markdown/src/components/Markdown.tsx
@@ -75,10 +75,8 @@ export const Markdown = ({
       {showToc && headings.length > 0 && (
         <nav className="rounded-3xl p-10 bg-yellow-50">
           {/*
-            A plain h2 rather than core's H2. That one is built for a heading in
-            a document: it is sized to be read as one, and carries the space
-            that separates it from the text above it. This is the label on a
-            box, at the top of it, with nothing above to separate it from.
+            The label on a box, not a heading in the document, so it does not
+            use core's H2 and its heading size and spacing.
           */}
           <h2 className="mb-4 font-bold text-h-xs-m sm:text-h-xs">
             {tocTitle}
@@ -88,8 +86,16 @@ export const Markdown = ({
           </Ul>
         </nav>
       )}
-      {/* The markup is sanitised in src/sanitize.ts before it gets here. */}
-      <div dangerouslySetInnerHTML={{ __html: html }} />
+      {/*
+        The document's blocks are children of this element, not of the wrapper,
+        so the space between them is set here.
+
+        The markup is sanitised in src/sanitize.ts before it gets here.
+      */}
+      <div
+        className="flex flex-col gap-8"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
     </div>
   )
 }

--- a/packages/markdown/src/decorate.ts
+++ b/packages/markdown/src/decorate.ts
@@ -5,11 +5,8 @@ import { classNames } from './marked/html'
 /**
  * Applies the look of the design system to the finished document.
  *
- * This runs over the sanitised DOM rather than inside the markdown renderer so
- * that a table written as raw HTML — 56 of the guide's documents do — is styled
- * the same as one written with pipes. The pipeline this replaces had the same
- * property, because rehype-raw turned the raw HTML into real nodes before the
- * tag to component mapping ran.
+ * Runs over the sanitised DOM rather than inside the markdown renderer, so that
+ * a table written as raw HTML is styled the same as one written with pipes.
  */
 
 export type HeadingItem = {
@@ -113,9 +110,7 @@ export const decorate = (
     const tag = element.tagName.toLowerCase()
 
     // One id, generated once, for headings from markdown and from raw HTML
-    // alike. The pipeline this replaces generated them in two passes that
-    // disagreed whenever a heading held an image, raw HTML or a directive, and
-    // the table of contents then linked to anchors that were not there.
+    // alike, so the table of contents and the body cannot disagree.
     if (HEADINGS.has(tag)) {
       const text = element.textContent ?? ''
       const asked = element.getAttribute('id')

--- a/packages/markdown/src/marked/attributes.ts
+++ b/packages/markdown/src/marked/attributes.ts
@@ -6,14 +6,11 @@ export type Attrs = Record<string, string>
 /**
  * Where `{#name}` is kept, apart from anything written as `key=value`.
  *
- * A sigil says something about the element itself and means the same on every
- * directive; an attribute is the directive's own, and each reads the ones it
- * knows. Keeping them in one place would let a directive that wanted an
- * attribute called `id` take the anchor's place, which is how the video on a
- * youtube embed came to be called `id` and stayed that way.
- *
+ * A sigil describes the element and means the same on every directive; an
+ * attribute belongs to whichever directive reads it. Held apart so that a
+ * directive wanting an attribute called `id` cannot take the anchor's place.
  * A key beginning with `#` cannot be written as `key=value`, since an attribute
- * name has to start with a letter, so there is nowhere for the two to meet.
+ * name has to start with a letter.
  */
 export const ANCHOR = '#id'
 

--- a/packages/markdown/src/marked/directives/card.ts
+++ b/packages/markdown/src/marked/directives/card.ts
@@ -12,8 +12,8 @@ const iconHtml = (name: string, altText: string): string =>
 
 export const cardRenderers: Record<string, DirectiveRenderer> = {
   card: ({ token, attrs, root, body, nl }) => {
-    // The tokenizer withholds linked from a card with no title, which has no
-    // link to give and so must not look as though it had one.
+    // Set by the tokenizer, and only when the card has a title to put the
+    // link on. A card without one must not look as though it were clickable.
     const isLink = Boolean(token.linked)
     const cls = classNames(
       styles.cardStyle,

--- a/packages/markdown/src/marked/html.ts
+++ b/packages/markdown/src/marked/html.ts
@@ -31,9 +31,9 @@ export const cleanUrl = (href: string | undefined): string | undefined => {
   if (href == null || href === '') return undefined
   const trimmed = stripControl(String(href)).trim()
   if (/^(?:javascript|vbscript|file):/i.test(trimmed)) return undefined
-  // Images written as data: used to be kept here and dropped nowhere, since
-  // DOMPurify allows the scheme on an img whatever ALLOWED_URI_REGEXP says. The
-  // content has no use for it, so both this and the sanitiser refuse it now.
+  // Refused here and in the sanitiser both: DOMPurify allows the scheme on an
+  // img whatever ALLOWED_URI_REGEXP says, so this is the only place a directive
+  // writing one is turned back.
   if (/^data:/i.test(trimmed)) return undefined
   return trimmed
 }

--- a/packages/markdown/src/marked/registry.ts
+++ b/packages/markdown/src/marked/registry.ts
@@ -6,11 +6,8 @@ export type DirectiveKind = typeof CONTAINER | typeof LEAF | typeof TEXT
 
 /**
  * The whitelist. A name that is not here is not a directive, and the text
- * carrying it is left alone.
- *
- * The remark pipeline this replaces turned any name into a tag of the same
- * name, so ordinary prose lost characters: "HH:MM" rendered as "HH", and
- * "chat:write" as "chat".
+ * carrying it is left alone — which is what keeps "HH:MM" and "chat:write"
+ * intact in the prose.
  */
 const STATIC: Record<string, DirectiveKind[]> = {
   card: [CONTAINER],

--- a/packages/markdown/src/marked/renderer.ts
+++ b/packages/markdown/src/marked/renderer.ts
@@ -10,13 +10,11 @@ import {
 } from './directives'
 
 /**
- * Builds what a directive renderer is given, then hands the token to the one
- * that knows it. The renderers themselves live in `directives/`, a file to a
- * feature: `card.ts` holds the card and everything written inside one, because
- * a title has to know whether the card gave it an href.
+ * Builds the context, then hands the token to the renderer that knows its name.
+ * The renderers live in `directives/`, a file to a feature, so that a card and
+ * everything written inside one stay together.
  *
- * A name with no renderer falls through to its own children, which is what a
- * directive the registry allows but nobody has drawn yet looks like.
+ * A name with no renderer falls through to its own children.
  */
 export function directiveRenderer(
   this: { parser: Parser },

--- a/packages/markdown/src/marked/tokenizer.ts
+++ b/packages/markdown/src/marked/tokenizer.ts
@@ -60,14 +60,12 @@ export const inlineStart = (src: string): number | undefined => {
 }
 
 /**
- * A grid of cards is a list. The cards are things of one kind, and how many
- * there are is part of what the page says; a grid holding anything else, or
- * cards and something else together, is a layout — prose beside a figure is not
- * two of something. Nothing is written to ask for this, the way nothing is
- * written to ask a run of "- " for a <ul>.
+ * A grid of cards is a list: the cards are things of one kind, and how many
+ * there are is part of what the page says. A grid holding anything else, or
+ * cards mixed with something else, is a layout.
  *
- * Marked here rather than worked out while rendering, because by then the
- * children have become one string and the boundaries between them are gone.
+ * Marked here rather than while rendering, because by then the children are one
+ * string with no boundaries between them.
  */
 const markCardList = (token: DirectiveToken): void => {
   if (!/^grid-cols-\d+$/.test(token.name)) return

--- a/packages/markdown/tests/__snapshots__/Markdown.test.tsx.snap
+++ b/packages/markdown/tests/__snapshots__/Markdown.test.tsx.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Markdown > directives > should render card 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><img class="object-cover mb-2 w-full aspect-[352/226]" src="/a.png" alt="図" data-sakura="card-img">
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><img class="object-cover mb-2 w-full aspect-[352/226]" src="/a.png" alt="図" data-sakura="card-img">
 <h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-title" id="タイトル">タイトル</h3>
 <div class="text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-description">説明</div>
 </div>
@@ -9,14 +9,14 @@ exports[`Markdown > directives > should render card 1`] = `
 `;
 
 exports[`Markdown > directives > should render cell 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><div data-sakura="cell"><img class="mb-4" src="/a.png" alt="図" data-sakura="cell-img">
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div data-sakura="cell"><img class="mb-4" src="/a.png" alt="図" data-sakura="cell-img">
 <p>本文</p>
 </div>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render faq 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><dl class="flex flex-col gap-8" data-sakura="faq"><dt class="flex flex-row gap-8 mt-8 text-h-med-m sm:text-h-med" data-sakura="faq-q"><span aria-hidden="true">Q</span><span>質問は？</span></dt>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><dl class="flex flex-col gap-8" data-sakura="faq"><dt class="flex flex-row gap-8 mt-8 text-h-med-m sm:text-h-med" data-sakura="faq-q"><span aria-hidden="true">Q</span><span>質問は？</span></dt>
 <dd class="flex flex-row items-start gap-8" data-sakura="faq-a"><span class="text-h-med-m sm:text-h-med !leading-none" aria-hidden="true">A</span><span>回答です。</span></dd>
 <dt class="flex flex-row gap-8 mt-8 text-h-med-m sm:text-h-med" data-sakura="faq-q"><span aria-hidden="true">Q</span><span>二つ目の質問は？</span></dt>
 <dd class="flex flex-row items-start gap-8" data-sakura="faq-a"><span class="text-h-med-m sm:text-h-med !leading-none" aria-hidden="true">A</span><span>二つ目の回答。</span></dd>
@@ -25,7 +25,7 @@ exports[`Markdown > directives > should render faq 1`] = `
 `;
 
 exports[`Markdown > directives > should render grid 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><ul class="flex flex-col md:grid md:grid-cols-3 gap-8" data-sakura="grid-cols-3"><li class="sm:grid"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-title" id="1つ目">1つ目</h3>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><ul class="flex flex-col md:grid md:grid-cols-3 gap-8" data-sakura="grid-cols-3"><li class="sm:grid"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-title" id="1つ目">1つ目</h3>
 </div></li>
 <li class="sm:grid"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-title" id="2つ目">2つ目</h3>
 </div></li>
@@ -34,7 +34,7 @@ exports[`Markdown > directives > should render grid 1`] = `
 `;
 
 exports[`Markdown > directives > should render gridMixed 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><div class="flex flex-col md:grid md:grid-cols-2 gap-8" data-sakura="grid-cols-2"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-title" id="1つ目">1つ目</h3>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="flex flex-col md:grid md:grid-cols-2 gap-8" data-sakura="grid-cols-2"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-title" id="1つ目">1つ目</h3>
 </div>
 <div data-sakura="cell"><p>本文</p>
 </div>
@@ -43,7 +43,7 @@ exports[`Markdown > directives > should render gridMixed 1`] = `
 `;
 
 exports[`Markdown > directives > should render gridOfCells 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><div class="flex flex-col md:grid md:grid-cols-2 gap-8" data-sakura="grid-cols-2"><div data-sakura="cell"><p><img src="/a.png" alt="alt"><br>本文1</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="flex flex-col md:grid md:grid-cols-2 gap-8" data-sakura="grid-cols-2"><div data-sakura="cell"><p><img src="/a.png" alt="alt"><br>本文1</p>
 </div>
 <div data-sakura="cell"><p>本文2</p>
 </div>
@@ -52,12 +52,12 @@ exports[`Markdown > directives > should render gridOfCells 1`] = `
 `;
 
 exports[`Markdown > directives > should render linkButton 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>ご案内です。<a class="inline-block text-button text-center cursor-pointer select-none touch-manipulation whitespace-nowrap outline-offset-2 border border-solid border-blue-900 hover:border-blue-1000 active:border-blue-1200 disabled:border-solid-gray-500 disabled:cursor-not-allowed text-blue-900 hover:text-blue-1000 active:text-blue-1200 bg-transparent hover:bg-blue-200 active:bg-blue-300 disabled:bg-transparent disabled:text-solid-gray-500 hover:underline hover:underline-offset-[calc(3/16*1rem)] focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:rounded-sm p-4 text-button leading-snug rounded-lg" href="/services" data-sakura="link-button">サービス一覧</a> をどうぞ。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>ご案内です。<a class="inline-block text-button text-center cursor-pointer select-none touch-manipulation whitespace-nowrap outline-offset-2 border border-solid border-blue-900 hover:border-blue-1000 active:border-blue-1200 disabled:border-solid-gray-500 disabled:cursor-not-allowed text-blue-900 hover:text-blue-1000 active:text-blue-1200 bg-transparent hover:bg-blue-200 active:bg-blue-300 disabled:bg-transparent disabled:text-solid-gray-500 hover:underline hover:underline-offset-[calc(3/16*1rem)] focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:rounded-sm p-4 text-button leading-snug rounded-lg" href="/services" data-sakura="link-button">サービス一覧</a> をどうぞ。</p>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render linkCard 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden relative z-0 group hover:outline hover:outline-2 hover:outline-black hover:bg-solid-gray-50 has-[a:focus-visible]:outline has-[a:focus-visible]:outline-4 has-[a:focus-visible]:outline-black has-[a:focus-visible]:outline-offset-[calc(2/16*1rem)] has-[a:focus-visible]:ring-[calc(2/16*1rem)] has-[a:focus-visible]:ring-yellow-300" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6 decoration-blue-900 underline underline-offset-[calc(3/16*1rem)] group-hover:text-blue-900 group-hover:decoration-[calc(3/16*1rem)]" data-sakura="card-title" id="タイトル"><a class="after:content-[''] after:absolute after:inset-0 after:z-10 focus-visible:outline-none" href="/x" data-sakura="card-title">タイトル</a></h3>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden relative z-0 group hover:outline hover:outline-2 hover:outline-black hover:bg-solid-gray-50 has-[a:focus-visible]:outline has-[a:focus-visible]:outline-4 has-[a:focus-visible]:outline-black has-[a:focus-visible]:outline-offset-[calc(2/16*1rem)] has-[a:focus-visible]:ring-[calc(2/16*1rem)] has-[a:focus-visible]:ring-yellow-300" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6 decoration-blue-900 underline underline-offset-[calc(3/16*1rem)] group-hover:text-blue-900 group-hover:decoration-[calc(3/16*1rem)]" data-sakura="card-title" id="タイトル"><a class="after:content-[''] after:absolute after:inset-0 after:z-10 focus-visible:outline-none" href="/x" data-sakura="card-title">タイトル</a></h3>
 <div class="text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-description">説明</div>
 <div class="sticky top-full text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6 flex justify-between items-center" data-sakura="card-footer"><span>2026年8月</span><span class="inline-flex items-center justify-center w-6 h-6 text-blue-1000 border border-blue-1000 rounded-full group-hover:bg-blue-1000 group-hover:text-white"><span aria-hidden="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap">arrow_forward</span><span class="sr-only"></span></span></div>
 </div>
@@ -65,32 +65,32 @@ exports[`Markdown > directives > should render linkCard 1`] = `
 `;
 
 exports[`Markdown > directives > should render linkCardWithoutTitle 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><div class="text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-description">説明</div>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><div class="text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-description">説明</div>
 <div class="sticky top-full text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-footer">2026年8月</div>
 </div>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render youtube 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><iframe title="動画タイトル" src="https://www.youtube-nocookie.com/embed/yXdbvBzxeb8" class="aspect-video w-full max-w-[470px]" style="width:560px;" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen="" loading="lazy" data-sakura="youtube"></iframe>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><iframe title="動画タイトル" src="https://www.youtube-nocookie.com/embed/yXdbvBzxeb8" class="aspect-video w-full max-w-[470px]" style="width:560px;" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen="" loading="lazy" data-sakura="youtube"></iframe>
 </div></div>"
 `;
 
 exports[`Markdown > heading shift > should move the headings down by the given amount 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><h2 id="見出し1" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">見出し1</h2>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><h2 id="見出し1" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">見出し1</h2>
 <h3 id="見出し2" class="text-h-sm-m sm:text-h-sm pt-[4rem] sm:pt-[4.5rem]">見出し2</h3>
 </div></div>"
 `;
 
 exports[`Markdown > headings > should render duplicated 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><h2 id="概要" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">概要</h2>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><h2 id="概要" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">概要</h2>
 <h2 id="概要-1" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">概要</h2>
 <h2 id="概要-2" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">概要</h2>
 </div></div>"
 `;
 
 exports[`Markdown > headings > should render japanese 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><h2 id="概要" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">概要</h2>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><h2 id="概要" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">概要</h2>
 <h2 id="はじめに概要" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">はじめに（概要）</h2>
 <h2 id="ab-テスト" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">A/B テスト</h2>
 <h2 id="サービスアプリ" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">サービス・アプリ</h2>
@@ -98,27 +98,27 @@ exports[`Markdown > headings > should render japanese 1`] = `
 `;
 
 exports[`Markdown > headings > should render withCode 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><h2 id="code-を含む見出し" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]"><code class="bg-solid-gray-50 font-mono">code</code> を含む見出し</h2>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><h2 id="code-を含む見出し" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]"><code class="bg-solid-gray-50 font-mono">code</code> を含む見出し</h2>
 </div></div>"
 `;
 
 exports[`Markdown > headings > should render withImage 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><h2 id="-会社概要" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]"><img src="/a.png" alt="ロゴ"> 会社概要</h2>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><h2 id="-会社概要" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]"><img src="/a.png" alt="ロゴ"> 会社概要</h2>
 </div></div>"
 `;
 
 exports[`Markdown > headings > should render withInlineHtml 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><h2 id="太字-タイトル" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]"><b>太字</b> タイトル</h2>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><h2 id="太字-タイトル" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]"><b>太字</b> タイトル</h2>
 </div></div>"
 `;
 
 exports[`Markdown > malformed html > should recover from closingBr 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>一行目<br>二行目<br>三行目<br>四行目</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>一行目<br>二行目<br>三行目<br>四行目</p>
 </div></div>"
 `;
 
 exports[`Markdown > malformed html > should recover from crossedNesting 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><ul class="list-disc [&amp;_&amp;]:list-circle [&amp;_&amp;_&amp;]:list-square pl-8">
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><ul class="list-disc [&amp;_&amp;]:list-circle [&amp;_&amp;_&amp;]:list-square pl-8">
 <details>
 <summary>まとめ</summary>
 中身
@@ -126,24 +126,24 @@ exports[`Markdown > malformed html > should recover from crossedNesting 1`] = `
 </ul></div></div>"
 `;
 
-exports[`Markdown > malformed html > should recover from mistypedClose 1`] = `"<div class="py-8 flex flex-col gap-8"><div><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420"><tbody><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">値</td></tr></tbody></table></div></div></div>"`;
+exports[`Markdown > malformed html > should recover from mistypedClose 1`] = `"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420"><tbody><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">値</td></tr></tbody></table></div></div></div>"`;
 
-exports[`Markdown > malformed html > should recover from unclosedCell 1`] = `"<div class="py-8 flex flex-col gap-8"><div><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420"><tbody><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">閉じ忘れ</td></tr><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">次の行</td></tr></tbody></table></div></div></div>"`;
+exports[`Markdown > malformed html > should recover from unclosedCell 1`] = `"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420"><tbody><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">閉じ忘れ</td></tr><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">次の行</td></tr></tbody></table></div></div></div>"`;
 
 exports[`Markdown > plain markdown > should render blockquote 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><blockquote>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><blockquote>
 <p>引用文<br>続き</p>
 </blockquote>
 </div></div>"
 `;
 
 exports[`Markdown > plain markdown > should render cjkSoftBreak 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>東京都<br>港区</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>東京都<br>港区</p>
 </div></div>"
 `;
 
 exports[`Markdown > plain markdown > should render codeFence 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><pre class="p-4 bg-solid-gray-50 rounded-lg whitespace-pre-wrap overflow-y-scroll"><code class="language-sh bg-solid-gray-50 font-mono">echo "hello"
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><pre class="p-4 bg-solid-gray-50 rounded-lg whitespace-pre-wrap overflow-y-scroll"><code class="language-sh bg-solid-gray-50 font-mono">echo "hello"
 </code></pre>
 <pre class="p-4 bg-solid-gray-50 rounded-lg whitespace-pre-wrap overflow-y-scroll"><code class="bg-solid-gray-50 font-mono">言語指定なし
 </code></pre>
@@ -151,12 +151,12 @@ exports[`Markdown > plain markdown > should render codeFence 1`] = `
 `;
 
 exports[`Markdown > plain markdown > should render footnote 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>本文<a href="%E8%84%9A%E6%B3%A8%E3%81%AE%E4%B8%AD%E8%BA%AB" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">^1</a></p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>本文<a href="%E8%84%9A%E6%B3%A8%E3%81%AE%E4%B8%AD%E8%BA%AB" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">^1</a></p>
 </div></div>"
 `;
 
 exports[`Markdown > plain markdown > should render gfmTable 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420">
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420">
 <thead>
 <tr class="border border-collapse border-solid-gray-420">
 <th class="p-2 bg-[#f8f8fb] text-label text-left border border-collapse border-solid-gray-420">見出し</th>
@@ -176,7 +176,7 @@ exports[`Markdown > plain markdown > should render gfmTable 1`] = `
 `;
 
 exports[`Markdown > plain markdown > should render headings 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><h1 id="見出し1" class="text-h-lg-m sm:text-h-lg pt-[2rem] sm:pt-[6.5rem]">見出し1</h1>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><h1 id="見出し1" class="text-h-lg-m sm:text-h-lg pt-[2rem] sm:pt-[6.5rem]">見出し1</h1>
 <h2 id="見出し-2" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">見出し 2</h2>
 <h3 id="見出し3" class="text-h-sm-m sm:text-h-sm pt-[4rem] sm:pt-[4.5rem]">見出し・3</h3>
 <h4 id="はじめに概要" class="text-h-xs-m sm:text-h-xs pt-[3.5rem] sm:pt-[4.5rem]">はじめに（概要）</h4>
@@ -184,17 +184,17 @@ exports[`Markdown > plain markdown > should render headings 1`] = `
 `;
 
 exports[`Markdown > plain markdown > should render image 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p><img src="/images/a.png" alt="代替テキスト"></p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p><img src="/images/a.png" alt="代替テキスト"></p>
 </div></div>"
 `;
 
 exports[`Markdown > plain markdown > should render links 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p><a href="/foo" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">内部</a> と <a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">外部<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a> と <a href="https://example.com/bare" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">https://example.com/bare<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p><a href="/foo" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">内部</a> と <a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">外部<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a> と <a href="https://example.com/bare" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">https://example.com/bare<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
 </div></div>"
 `;
 
 exports[`Markdown > plain markdown > should render list 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><ul class="list-disc [&amp;_&amp;]:list-circle [&amp;_&amp;_&amp;]:list-square pl-8">
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><ul class="list-disc [&amp;_&amp;]:list-circle [&amp;_&amp;_&amp;]:list-square pl-8">
 <li>項目1</li>
 <li>項目2<ul class="list-disc [&amp;_&amp;]:list-circle [&amp;_&amp;_&amp;]:list-square pl-8">
 <li>入れ子<ul class="list-disc [&amp;_&amp;]:list-circle [&amp;_&amp;_&amp;]:list-square pl-8">
@@ -212,17 +212,17 @@ exports[`Markdown > plain markdown > should render list 1`] = `
 `;
 
 exports[`Markdown > plain markdown > should render paragraph 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>段落です。<strong>強調</strong> と <em>斜体</em> と <code class="bg-solid-gray-50 font-mono">コード</code> と <del>取り消し</del>。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>段落です。<strong>強調</strong> と <em>斜体</em> と <code class="bg-solid-gray-50 font-mono">コード</code> と <del>取り消し</del>。</p>
 </div></div>"
 `;
 
 exports[`Markdown > plain markdown > should render rule 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><hr>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><hr>
 </div></div>"
 `;
 
 exports[`Markdown > raw html > should render details 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><details>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><details>
 <summary>詳細はこちら</summary><ul class="list-disc [&amp;_&amp;]:list-circle [&amp;_&amp;_&amp;]:list-square pl-8">
 <li>リスト項目</li>
 </ul>
@@ -242,25 +242,25 @@ exports[`Markdown > raw html > should render details 1`] = `
 `;
 
 exports[`Markdown > raw html > should render externalAnchor 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p><a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">外部リンク<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p><a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">外部リンク<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
 </div></div>"
 `;
 
 exports[`Markdown > raw html > should render inlineTags 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>本文に <strong>太字</strong> と <u>下線</u> と <sup>（※1）</sup> と <small>小</small>。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>本文に <strong>太字</strong> と <u>下線</u> と <sup>（※1）</sup> と <small>小</small>。</p>
 </div></div>"
 `;
 
 exports[`Markdown > raw html > should render styledBlock 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><div style="background-color: #E8F1FE; padding: 12px 16px; border-radius: 8px; margin: 0 24px;">
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div style="background-color: #E8F1FE; padding: 12px 16px; border-radius: 8px; margin: 0 24px;">
 注記のボックス
 </div></div></div>"
 `;
 
-exports[`Markdown > raw html > should render styledImg 1`] = `"<div class="py-8 flex flex-col gap-8"><div><img src="/images/a.png" alt="図" style="width: 800px; color-scheme: light;"></div></div>"`;
+exports[`Markdown > raw html > should render styledImg 1`] = `"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><img src="/images/a.png" alt="図" style="width: 800px; color-scheme: light;"></div></div>"`;
 
 exports[`Markdown > raw html > should render tableSpan 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420">
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420">
 <caption class="text-left">表:01 キャプション</caption>
 <colgroup><col style="width: 15%;"><col style="width: auto;"></colgroup>
 <thead><tr class="border border-collapse border-solid-gray-420"><th colspan="2" class="p-2 bg-[#f8f8fb] text-label text-left border border-collapse border-solid-gray-420">見出し</th></tr></thead>
@@ -382,7 +382,7 @@ exports[`Markdown > table of contents > should render the table of contents when
   
   disabled:border-solid-gray-500
   [overflow-wrap:anywhere]
-" href="#章2">章2</a></li></ul></nav><div><h1 id="章1" class="text-h-lg-m sm:text-h-lg pt-[2rem] sm:pt-[6.5rem]">章1</h1>
+" href="#章2">章2</a></li></ul></nav><div class="flex flex-col gap-8"><h1 id="章1" class="text-h-lg-m sm:text-h-lg pt-[2rem] sm:pt-[6.5rem]">章1</h1>
 <h2 id="節1" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">節1</h2>
 <h3 id="項1" class="text-h-sm-m sm:text-h-sm pt-[4rem] sm:pt-[4.5rem]">項1</h3>
 <h2 id="節2" class="text-h-med-m sm:text-h-med pt-[4rem] sm:pt-[4.5rem]">節2</h2>
@@ -391,56 +391,56 @@ exports[`Markdown > table of contents > should render the table of contents when
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave chapter alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>第1章:はじめに</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>第1章:はじめに</p>
 </div></div>"
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave colonWord alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>参照:example と note:important を見てください。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>参照:example と note:important を見てください。</p>
 </div></div>"
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave emoji alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>絵文字 :smile: です。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>絵文字 :smile: です。</p>
 </div></div>"
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave functionCall alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>関数 foo:bar() を呼びます。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>関数 foo:bar() を呼びます。</p>
 </div></div>"
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave linkLabel alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p><a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">AWSドキュメント:AWS PrivateLink<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p><a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">AWSドキュメント:AWS PrivateLink<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
 </div></div>"
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave ratio alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>比率は 16:9 です。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>比率は 16:9 です。</p>
 </div></div>"
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave scopeName alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>スコープ chat:write を付与する。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>スコープ chat:write を付与する。</p>
 </div></div>"
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave time alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>開始は 10:30 です。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>開始は 10:30 です。</p>
 </div></div>"
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave timeFormat alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>開始時刻は HH:MM 形式で記載する。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>開始時刻は HH:MM 形式で記載する。</p>
 </div></div>"
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave todo alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>TODO: あとで直す</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>TODO: あとで直す</p>
 </div></div>"
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave xmlAttr alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div><p>属性は xml:lang です。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>属性は xml:lang です。</p>
 </div></div>"
 `;


### PR DESCRIPTION
## Why

The wrapper carries `flex flex-col gap-8`, but the document's blocks are children of the element holding the rendered HTML, one level below it. The gap fell between the table of contents and that element, and nowhere inside it, so a heading sat directly on the paragraph under it.

## What

```diff
-<div dangerouslySetInnerHTML={{ __html: html }} />
+<div className="flex flex-col gap-8" dangerouslySetInnerHTML={{ __html: html }} />
```

32px now falls between every block — heading to paragraph, paragraph to table, and so on down the page. Measured on the example document:

```
h3 → p: 32px    p → p: 32px    p → h4: 32px
```

Comments across the package are cut down to the intent behind the code.

`@sakura-ui/markdown` 0.4.2, root 0.5.4. `pnpm lint`, `pnpm build`, `pnpm test` pass; 90 tests.

---

# 日本語

## WHY

ラッパーは `flex flex-col gap-8` を持ちますが、ドキュメントの各ブロックは、その 1 つ下にある描画済み HTML を収める要素の子です。gap は目次とその要素の間にだけ落ち、中には届いていませんでした。そのため見出しの直下に段落が接していました。

## WHAT

```diff
-<div dangerouslySetInnerHTML={{ __html: html }} />
+<div className="flex flex-col gap-8" dangerouslySetInnerHTML={{ __html: html }} />
```

すべてのブロック間に 32px が入ります。見出しと段落、段落と表、以下同様。examples のドキュメントでの実測値:

```
h3 → p: 32px    p → p: 32px    p → h4: 32px
```

あわせて、パッケージ全体のコメントを意図の説明だけに削ります。

`@sakura-ui/markdown` 0.4.2、root 0.5.4。`pnpm lint` / `pnpm build` / `pnpm test` が通ります（テスト 90 件）。
