### PR TITLE
feat: add the img directive, and fix rel on links that open elsewhere

### DIFF
--- a/examples/src/pages/markdownSample.ts
+++ b/examples/src/pages/markdownSample.ts
@@ -174,6 +174,10 @@ The second cell.
 ::faq-a[Yes. It is sanitised on the way through.]
 :::
 
+### Sized image
+
+::img{src=/sakura-ui/bg-mt.webp alt="The mountain again, at 320px" width=320}
+
 ### Video
 
 The address is written the way it is copied from the browser.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/sakura-ui",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "keywords": [],
   "author": "glassonion1",
   "homepage": "https://github.com/glassonion1/sakura-ui",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/core",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "",
   "keywords": [
     "react",

--- a/packages/core/src/components/Link.tsx
+++ b/packages/core/src/components/Link.tsx
@@ -20,6 +20,22 @@ export namespace Link {
   }
 }
 
+/**
+ * A link that opens elsewhere must not hand the opener to the page it opens.
+ * Merged with what the caller asked for rather than replacing it, so a
+ * `rel="nofollow"` does not take `noopener` away with it.
+ */
+const externalRel = (rel: unknown): string =>
+  Array.from(
+    new Set([
+      'noopener',
+      'noreferrer',
+      ...String(rel ?? '')
+        .split(/\s+/)
+        .filter(Boolean)
+    ])
+  ).join(' ')
+
 export const Link = <T extends React.ElementType = 'a'>(
   props: Link.Props<T> & Omit<React.ComponentProps<T>, keyof Link.Props<T>>
 ) => {
@@ -32,6 +48,7 @@ export const Link = <T extends React.ElementType = 'a'>(
         className={cx(style, className)}
         target="_blank"
         {...restProps}
+        rel={externalRel(restProps.rel)}
       >
         <span>{children}</span>
         <Icon opticalSize={16} altText="Opens in new tab" className="ml-0.5">

--- a/packages/core/tests/Link.test.tsx
+++ b/packages/core/tests/Link.test.tsx
@@ -39,6 +39,47 @@ describe('Link', () => {
     expect(text).toBeInTheDocument()
   })
 
+  it('should not hand the opener to the page it opens', async () => {
+    render(<Link href="https://example.com">Button</Link>)
+
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
+    )
+  })
+
+  it('should keep the rel the caller asked for as well', async () => {
+    render(
+      <Link href="https://example.com" rel="nofollow">
+        Button
+      </Link>
+    )
+
+    const rel = screen.getByRole('link').getAttribute('rel')?.split(' ')
+    expect(rel).toContain('noopener')
+    expect(rel).toContain('noreferrer')
+    expect(rel).toContain('nofollow')
+  })
+
+  it('should not repeat a rel the caller already asked for', async () => {
+    render(
+      <Link href="https://example.com" rel="noopener">
+        Button
+      </Link>
+    )
+
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'rel',
+      'noopener noreferrer'
+    )
+  })
+
+  it('should leave a link that stays on the page without a rel', async () => {
+    render(<Link href="/">Button</Link>)
+
+    expect(screen.getByRole('link')).not.toHaveAttribute('rel')
+  })
+
   it('should labeled text from Button', async () => {
     render(<Link href="/">here</Link>)
 

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -116,6 +116,22 @@ instead.
 ```
 <img width="288" alt="スクリーンショット 2024-07-26 23 44 39" src="https://github.com/user-attachments/assets/997ccf27-4d83-4fb5-b173-ae94cd7d76cb">
 
+### Image
+
+`![alt](src)` has nowhere to put a size, so `::img` takes one. `width` and
+`height` are pixels; either on its own leaves the other to follow the
+proportions of the image.
+
+```
+::img{src=/photo.jpg alt="A field at dawn" width=520}
+```
+
+A width also caps the image at the width of its column, so a number larger than
+the screen shrinks rather than overflowing.
+
+Write `alt` for anything a reader would miss without it. An image that only
+decorates takes `alt=""`, which tells a screen reader to skip it.
+
 ### YouTube
 
 The address of the video, as it is copied from the browser. The watch page, the

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -363,7 +363,7 @@ using them is what keeps a new directive behaving like the others:
 
 | | |
 |---|---|
-| `root(…)` | Attributes for the element the directive **is**. Adds the id from `{#name}`, and `data-sakura`, which tells `decorate.ts` the element is dressed already and to leave its classes alone. Headings are the exception: one rendered by a directive still has an id generated for it and still reaches the table of contents, which is how a card title gets there. |
+| `root(…)` | Attributes for the element the directive **is**. Adds the id from `{#name}`, and `data-styled`, which tells `decorate.ts` the element is dressed already and to leave its classes alone. Headings are the exception: one rendered by a directive still has an id generated for it and still reaches the table of contents, which is how a card title gets there. |
 | `own(…)` | The same without the id, for elements **inside** it. A link card's title is a heading around an anchor; only the heading is the directive. |
 | `body()` | The children, already rendered — inline for a `TEXT` or `LEAF`, block for a `CONTAINER`. |
 

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/markdown",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "",
   "keywords": [
     "markdown"

--- a/packages/markdown/src/decorate.ts
+++ b/packages/markdown/src/decorate.ts
@@ -40,6 +40,20 @@ const CLASS_BY_TAG: Record<string, string> = {
 const isDirectiveOutput = (element: Element) =>
   element.hasAttribute('data-styled')
 
+/**
+ * A link that opens elsewhere must not hand the opener to the page it opens.
+ * Merged with what the document asked for rather than replacing it, so a
+ * `rel="nofollow"` does not take `noopener` away with it.
+ */
+const externalRel = (rel: string | null): string =>
+  Array.from(
+    new Set([
+      'noopener',
+      'noreferrer',
+      ...(rel ?? '').split(/\s+/).filter(Boolean)
+    ])
+  ).join(' ')
+
 const addClass = (element: Element, value: string) => {
   const merged = classNames(element.getAttribute('class') ?? '', value)
   if (merged) element.setAttribute('class', merged)
@@ -131,9 +145,7 @@ export const decorate = (
         element.getAttribute('target') === '_blank'
       ) {
         element.setAttribute('target', '_blank')
-        // The content writes target="_blank" 41 times and rel not once, which
-        // leaves the opened page holding a handle on this one.
-        element.setAttribute('rel', 'noopener noreferrer')
+        element.setAttribute('rel', externalRel(element.getAttribute('rel')))
         appendNewTabIcon(element, document)
       }
     }

--- a/packages/markdown/src/decorate.ts
+++ b/packages/markdown/src/decorate.ts
@@ -38,7 +38,7 @@ const CLASS_BY_TAG: Record<string, string> = {
 
 /** Elements a directive rendered are already dressed; leave them be. */
 const isDirectiveOutput = (element: Element) =>
-  element.hasAttribute('data-sakura')
+  element.hasAttribute('data-styled')
 
 const addClass = (element: Element, value: string) => {
   const merged = classNames(element.getAttribute('class') ?? '', value)
@@ -53,10 +53,10 @@ const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
  * the Icon component does.
  */
 const appendNewTabIcon = (anchor: Element, document: Document) => {
-  if (anchor.querySelector('[data-sakura-new-tab]')) return
+  if (anchor.querySelector('[data-new-tab]')) return
   const glyph = document.createElement('span')
   glyph.setAttribute('aria-hidden', 'true')
-  glyph.setAttribute('data-sakura-new-tab', 'true')
+  glyph.setAttribute('data-new-tab', 'true')
   glyph.setAttribute(
     'class',
     classNames(styles.iconSizeStyle[16], styles.iconStyle, 'ml-0.5')
@@ -145,10 +145,10 @@ export const decorate = (
   // A wide table scrolls inside its own box rather than pushing the page.
   for (const table of Array.from(root.querySelectorAll('table'))) {
     const parent = table.parentElement
-    if (parent?.dataset?.sakuraTableContainer === 'true') continue
+    if (parent?.dataset?.tableContainer === 'true') continue
     const container = document.createElement('div')
     container.setAttribute('class', classNames(styles.overflowContainerStyle))
-    container.dataset.sakuraTableContainer = 'true'
+    container.dataset.tableContainer = 'true'
     table.replaceWith(container)
     container.appendChild(table)
   }

--- a/packages/markdown/src/marked/directives/image.ts
+++ b/packages/markdown/src/marked/directives/image.ts
@@ -1,0 +1,29 @@
+import { classNames, cleanUrl } from '../html'
+import type { DirectiveRenderer } from './context'
+
+/**
+ * `width` and `height` are pixels. `max-width` goes with a width so that the
+ * image shrinks inside its column on a narrow screen rather than overflowing
+ * it; with a height alone there is nothing to overflow, since the width
+ * follows the proportions.
+ */
+const sizeStyle = (
+  width: string | undefined,
+  height: string | undefined
+): string | undefined => {
+  const rules: string[] = []
+  if (width) rules.push(`width:${width}px`)
+  if (height) rules.push(`height:${height}px`)
+  if (width) rules.push('max-width:100%')
+  return rules.length > 0 ? rules.join(';') : undefined
+}
+
+export const imageRenderers: Record<string, DirectiveRenderer> = {
+  img: ({ attrs, root, nl }) =>
+    `<img${root({
+      class: classNames(attrs.class),
+      src: cleanUrl(attrs.src),
+      alt: attrs.alt ?? '',
+      style: sizeStyle(attrs.width, attrs.height)
+    })}>${nl}`
+}

--- a/packages/markdown/src/marked/directives/index.ts
+++ b/packages/markdown/src/marked/directives/index.ts
@@ -2,6 +2,7 @@ import { GRID_RE } from '../registry'
 import { cardRenderers } from './card'
 import type { DirectiveRenderer } from './context'
 import { faqRenderers } from './faq'
+import { imageRenderers } from './image'
 import { cellRenderers, grid } from './grid'
 import { linkButtonRenderers } from './linkButton'
 import { youtubeRenderers } from './youtube'
@@ -10,6 +11,7 @@ const BY_NAME: Record<string, DirectiveRenderer> = {
   ...cardRenderers,
   ...cellRenderers,
   ...faqRenderers,
+  ...imageRenderers,
   ...youtubeRenderers,
   ...linkButtonRenderers
 }

--- a/packages/markdown/src/marked/html.ts
+++ b/packages/markdown/src/marked/html.ts
@@ -40,10 +40,23 @@ export const cleanUrl = (href: string | undefined): string | undefined => {
 
 export type AttrValue = string | boolean | undefined | null
 
+/**
+ * Attributes where an empty value says something, and so is written out. On an
+ * image an empty alt marks it as decoration; leaving the attribute off instead
+ * makes a screen reader read the file name.
+ */
+const KEEP_WHEN_EMPTY = new Set(['alt'])
+
 /** `{a: 'x', b: true, c: undefined}` becomes ` a="x" b` */
 export const attrsToHtml = (attrs: Record<string, AttrValue>): string =>
   Object.entries(attrs)
-    .filter(([, v]) => v !== undefined && v !== null && v !== false && v !== '')
+    .filter(
+      ([k, v]) =>
+        v !== undefined &&
+        v !== null &&
+        v !== false &&
+        (v !== '' || KEEP_WHEN_EMPTY.has(k))
+    )
     .map(([k, v]) => (v === true ? ` ${k}` : ` ${k}="${escapeHtml(v)}"`))
     .join('')
 

--- a/packages/markdown/src/marked/registry.ts
+++ b/packages/markdown/src/marked/registry.ts
@@ -20,6 +20,7 @@ const STATIC: Record<string, DirectiveKind[]> = {
   'faq-a': [LEAF, CONTAINER],
   cell: [CONTAINER],
   'cell-img': [LEAF],
+  img: [LEAF],
   youtube: [LEAF, CONTAINER],
   'link-button': [TEXT]
 }

--- a/packages/markdown/src/marked/renderer.ts
+++ b/packages/markdown/src/marked/renderer.ts
@@ -24,10 +24,10 @@ export function directiveRenderer(
   const { name, kind, attrs, tokens } = token
   const nl = kind === TEXT ? '' : '\n'
 
-  // Marks what the directive dressed itself, so that the pass which styles the
-  // rest of the document leaves it alone.
+  // Marks the element as dressed, so that the pass which styles the rest of
+  // the document leaves it alone. The value names the directive it came from.
   const own: DirectiveContext['own'] = (values) =>
-    attrsToHtml({ ...values, 'data-sakura': name })
+    attrsToHtml({ ...values, 'data-styled': name })
 
   const context: DirectiveContext = {
     token,

--- a/packages/markdown/src/sanitize.ts
+++ b/packages/markdown/src/sanitize.ts
@@ -168,9 +168,16 @@ const purifier = (): DOMPurify => {
         element.removeAttribute('style')
       }
     }
-    // A link that opens elsewhere must not hand the opener over with it.
+    // A link that opens elsewhere must not hand the opener over with it. What
+    // the document asked for is kept alongside rather than replaced.
     if (element.getAttribute('target') === '_blank') {
-      element.setAttribute('rel', 'noopener noreferrer')
+      const asked = (element.getAttribute('rel') ?? '').split(/\s+/)
+      element.setAttribute(
+        'rel',
+        Array.from(
+          new Set(['noopener', 'noreferrer', ...asked.filter(Boolean)])
+        ).join(' ')
+      )
     }
   })
   return instance

--- a/packages/markdown/tests/__snapshots__/Markdown.test.tsx.snap
+++ b/packages/markdown/tests/__snapshots__/Markdown.test.tsx.snap
@@ -1,78 +1,78 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Markdown > directives > should render card 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><img class="object-cover mb-2 w-full aspect-[352/226]" src="/a.png" alt="図" data-sakura="card-img">
-<h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-title" id="タイトル">タイトル</h3>
-<div class="text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-description">説明</div>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-styled="card"><img class="object-cover mb-2 w-full aspect-[352/226]" src="/a.png" alt="図" data-styled="card-img">
+<h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-styled="card-title" id="タイトル">タイトル</h3>
+<div class="text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-styled="card-description">説明</div>
 </div>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render cell 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div data-sakura="cell"><img class="mb-4" src="/a.png" alt="図" data-sakura="cell-img">
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div data-styled="cell"><img class="mb-4" src="/a.png" alt="図" data-styled="cell-img">
 <p>本文</p>
 </div>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render faq 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><dl class="flex flex-col gap-8" data-sakura="faq"><dt class="flex flex-row gap-8 mt-8 text-h-med-m sm:text-h-med" data-sakura="faq-q"><span aria-hidden="true">Q</span><span>質問は？</span></dt>
-<dd class="flex flex-row items-start gap-8" data-sakura="faq-a"><span class="text-h-med-m sm:text-h-med !leading-none" aria-hidden="true">A</span><span>回答です。</span></dd>
-<dt class="flex flex-row gap-8 mt-8 text-h-med-m sm:text-h-med" data-sakura="faq-q"><span aria-hidden="true">Q</span><span>二つ目の質問は？</span></dt>
-<dd class="flex flex-row items-start gap-8" data-sakura="faq-a"><span class="text-h-med-m sm:text-h-med !leading-none" aria-hidden="true">A</span><span>二つ目の回答。</span></dd>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><dl class="flex flex-col gap-8" data-styled="faq"><dt class="flex flex-row gap-8 mt-8 text-h-med-m sm:text-h-med" data-styled="faq-q"><span aria-hidden="true">Q</span><span>質問は？</span></dt>
+<dd class="flex flex-row items-start gap-8" data-styled="faq-a"><span class="text-h-med-m sm:text-h-med !leading-none" aria-hidden="true">A</span><span>回答です。</span></dd>
+<dt class="flex flex-row gap-8 mt-8 text-h-med-m sm:text-h-med" data-styled="faq-q"><span aria-hidden="true">Q</span><span>二つ目の質問は？</span></dt>
+<dd class="flex flex-row items-start gap-8" data-styled="faq-a"><span class="text-h-med-m sm:text-h-med !leading-none" aria-hidden="true">A</span><span>二つ目の回答。</span></dd>
 </dl>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render grid 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><ul class="flex flex-col md:grid md:grid-cols-3 gap-8" data-sakura="grid-cols-3"><li class="sm:grid"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-title" id="1つ目">1つ目</h3>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><ul class="flex flex-col md:grid md:grid-cols-3 gap-8" data-styled="grid-cols-3"><li class="sm:grid"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-styled="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-styled="card-title" id="1つ目">1つ目</h3>
 </div></li>
-<li class="sm:grid"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-title" id="2つ目">2つ目</h3>
+<li class="sm:grid"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-styled="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-styled="card-title" id="2つ目">2つ目</h3>
 </div></li>
 </ul>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render gridMixed 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="flex flex-col md:grid md:grid-cols-2 gap-8" data-sakura="grid-cols-2"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-title" id="1つ目">1つ目</h3>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="flex flex-col md:grid md:grid-cols-2 gap-8" data-styled="grid-cols-2"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-styled="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6" data-styled="card-title" id="1つ目">1つ目</h3>
 </div>
-<div data-sakura="cell"><p>本文</p>
+<div data-styled="cell"><p>本文</p>
 </div>
 </div>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render gridOfCells 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="flex flex-col md:grid md:grid-cols-2 gap-8" data-sakura="grid-cols-2"><div data-sakura="cell"><p><img src="/a.png" alt="alt"><br>本文1</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="flex flex-col md:grid md:grid-cols-2 gap-8" data-styled="grid-cols-2"><div data-styled="cell"><p><img src="/a.png" alt="alt"><br>本文1</p>
 </div>
-<div data-sakura="cell"><p>本文2</p>
+<div data-styled="cell"><p>本文2</p>
 </div>
 </div>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render linkButton 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>ご案内です。<a class="inline-block text-button text-center cursor-pointer select-none touch-manipulation whitespace-nowrap outline-offset-2 border border-solid border-blue-900 hover:border-blue-1000 active:border-blue-1200 disabled:border-solid-gray-500 disabled:cursor-not-allowed text-blue-900 hover:text-blue-1000 active:text-blue-1200 bg-transparent hover:bg-blue-200 active:bg-blue-300 disabled:bg-transparent disabled:text-solid-gray-500 hover:underline hover:underline-offset-[calc(3/16*1rem)] focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:rounded-sm p-4 text-button leading-snug rounded-lg" href="/services" data-sakura="link-button">サービス一覧</a> をどうぞ。</p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p>ご案内です。<a class="inline-block text-button text-center cursor-pointer select-none touch-manipulation whitespace-nowrap outline-offset-2 border border-solid border-blue-900 hover:border-blue-1000 active:border-blue-1200 disabled:border-solid-gray-500 disabled:cursor-not-allowed text-blue-900 hover:text-blue-1000 active:text-blue-1200 bg-transparent hover:bg-blue-200 active:bg-blue-300 disabled:bg-transparent disabled:text-solid-gray-500 hover:underline hover:underline-offset-[calc(3/16*1rem)] focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:rounded-sm p-4 text-button leading-snug rounded-lg" href="/services" data-styled="link-button">サービス一覧</a> をどうぞ。</p>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render linkCard 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden relative z-0 group hover:outline hover:outline-2 hover:outline-black hover:bg-solid-gray-50 has-[a:focus-visible]:outline has-[a:focus-visible]:outline-4 has-[a:focus-visible]:outline-black has-[a:focus-visible]:outline-offset-[calc(2/16*1rem)] has-[a:focus-visible]:ring-[calc(2/16*1rem)] has-[a:focus-visible]:ring-yellow-300" data-sakura="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6 decoration-blue-900 underline underline-offset-[calc(3/16*1rem)] group-hover:text-blue-900 group-hover:decoration-[calc(3/16*1rem)]" data-sakura="card-title" id="タイトル"><a class="after:content-[''] after:absolute after:inset-0 after:z-10 focus-visible:outline-none" href="/x" data-sakura="card-title">タイトル</a></h3>
-<div class="text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-description">説明</div>
-<div class="sticky top-full text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6 flex justify-between items-center" data-sakura="card-footer"><span>2026年8月</span><span class="inline-flex items-center justify-center w-6 h-6 text-blue-1000 border border-blue-1000 rounded-full group-hover:bg-blue-1000 group-hover:text-white"><span aria-hidden="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap">arrow_forward</span><span class="sr-only"></span></span></div>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden relative z-0 group hover:outline hover:outline-2 hover:outline-black hover:bg-solid-gray-50 has-[a:focus-visible]:outline has-[a:focus-visible]:outline-4 has-[a:focus-visible]:outline-black has-[a:focus-visible]:outline-offset-[calc(2/16*1rem)] has-[a:focus-visible]:ring-[calc(2/16*1rem)] has-[a:focus-visible]:ring-yellow-300" data-styled="card"><h3 class="m-0 text-base leading-[2rem] font-medium first:pt-4 pt-2 last:pb-4 px-6 decoration-blue-900 underline underline-offset-[calc(3/16*1rem)] group-hover:text-blue-900 group-hover:decoration-[calc(3/16*1rem)]" data-styled="card-title" id="タイトル"><a class="after:content-[''] after:absolute after:inset-0 after:z-10 focus-visible:outline-none" href="/x" data-styled="card-title">タイトル</a></h3>
+<div class="text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-styled="card-description">説明</div>
+<div class="sticky top-full text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6 flex justify-between items-center" data-styled="card-footer"><span>2026年8月</span><span class="inline-flex items-center justify-center w-6 h-6 text-blue-1000 border border-blue-1000 rounded-full group-hover:bg-blue-1000 group-hover:text-white"><span aria-hidden="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap">arrow_forward</span><span class="sr-only"></span></span></div>
 </div>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render linkCardWithoutTitle 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-sakura="card"><div class="text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-description">説明</div>
-<div class="sticky top-full text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-sakura="card-footer">2026年8月</div>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="border border-solid border-solid-gray-500 rounded-2xl sm:rounded-3xl text-solid-gray-900 overflow-hidden" data-styled="card"><div class="text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-styled="card-description">説明</div>
+<div class="sticky top-full text-base-sm leading-[1.85rem] first:pt-4 pt-2 last:pb-4 px-6" data-styled="card-footer">2026年8月</div>
 </div>
 </div></div>"
 `;
 
 exports[`Markdown > directives > should render youtube 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><iframe title="動画タイトル" src="https://www.youtube-nocookie.com/embed/yXdbvBzxeb8" class="aspect-video w-full max-w-[470px]" style="width:560px;" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen="" loading="lazy" data-sakura="youtube"></iframe>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><iframe title="動画タイトル" src="https://www.youtube-nocookie.com/embed/yXdbvBzxeb8" class="aspect-video w-full max-w-[470px]" style="width:560px;" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen="" loading="lazy" data-styled="youtube"></iframe>
 </div></div>"
 `;
 
@@ -126,9 +126,9 @@ exports[`Markdown > malformed html > should recover from crossedNesting 1`] = `
 </ul></div></div>"
 `;
 
-exports[`Markdown > malformed html > should recover from mistypedClose 1`] = `"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420"><tbody><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">値</td></tr></tbody></table></div></div></div>"`;
+exports[`Markdown > malformed html > should recover from mistypedClose 1`] = `"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-table-container="true"><table class="border border-collapse border-solid-gray-420"><tbody><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">値</td></tr></tbody></table></div></div></div>"`;
 
-exports[`Markdown > malformed html > should recover from unclosedCell 1`] = `"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420"><tbody><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">閉じ忘れ</td></tr><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">次の行</td></tr></tbody></table></div></div></div>"`;
+exports[`Markdown > malformed html > should recover from unclosedCell 1`] = `"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-table-container="true"><table class="border border-collapse border-solid-gray-420"><tbody><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">閉じ忘れ</td></tr><tr class="border border-collapse border-solid-gray-420"><td class="p-2 text-label border border-collapse border-solid-gray-420">次の行</td></tr></tbody></table></div></div></div>"`;
 
 exports[`Markdown > plain markdown > should render blockquote 1`] = `
 "<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><blockquote>
@@ -156,7 +156,7 @@ exports[`Markdown > plain markdown > should render footnote 1`] = `
 `;
 
 exports[`Markdown > plain markdown > should render gfmTable 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420">
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-table-container="true"><table class="border border-collapse border-solid-gray-420">
 <thead>
 <tr class="border border-collapse border-solid-gray-420">
 <th class="p-2 bg-[#f8f8fb] text-label text-left border border-collapse border-solid-gray-420">見出し</th>
@@ -189,7 +189,7 @@ exports[`Markdown > plain markdown > should render image 1`] = `
 `;
 
 exports[`Markdown > plain markdown > should render links 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p><a href="/foo" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">内部</a> と <a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">外部<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a> と <a href="https://example.com/bare" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">https://example.com/bare<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p><a href="/foo" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">内部</a> と <a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">外部<span aria-hidden="true" data-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a> と <a href="https://example.com/bare" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">https://example.com/bare<span aria-hidden="true" data-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
 </div></div>"
 `;
 
@@ -226,7 +226,7 @@ exports[`Markdown > raw html > should render details 1`] = `
 <summary>詳細はこちら</summary><ul class="list-disc [&amp;_&amp;]:list-circle [&amp;_&amp;_&amp;]:list-square pl-8">
 <li>リスト項目</li>
 </ul>
-<div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420">
+<div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-table-container="true"><table class="border border-collapse border-solid-gray-420">
 <thead>
 <tr class="border border-collapse border-solid-gray-420">
 <th class="p-2 bg-[#f8f8fb] text-label text-left border border-collapse border-solid-gray-420">表</th>
@@ -242,7 +242,7 @@ exports[`Markdown > raw html > should render details 1`] = `
 `;
 
 exports[`Markdown > raw html > should render externalAnchor 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p><a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">外部リンク<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p><a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">外部リンク<span aria-hidden="true" data-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
 </div></div>"
 `;
 
@@ -260,7 +260,7 @@ exports[`Markdown > raw html > should render styledBlock 1`] = `
 exports[`Markdown > raw html > should render styledImg 1`] = `"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><img src="/images/a.png" alt="図" style="width: 800px; color-scheme: light;"></div></div>"`;
 
 exports[`Markdown > raw html > should render tableSpan 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-sakura-table-container="true"><table class="border border-collapse border-solid-gray-420">
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><div class="w-full overflow-x-auto whitespace-nowrap print:overflow-visible print:whitespace-normal" data-table-container="true"><table class="border border-collapse border-solid-gray-420">
 <caption class="text-left">表:01 キャプション</caption>
 <colgroup><col style="width: 15%;"><col style="width: auto;"></colgroup>
 <thead><tr class="border border-collapse border-solid-gray-420"><th colspan="2" class="p-2 bg-[#f8f8fb] text-label text-left border border-collapse border-solid-gray-420">見出し</th></tr></thead>
@@ -411,7 +411,7 @@ exports[`Markdown > text that only looks like a directive > should leave functio
 `;
 
 exports[`Markdown > text that only looks like a directive > should leave linkLabel alone 1`] = `
-"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p><a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">AWSドキュメント:AWS PrivateLink<span aria-hidden="true" data-sakura-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
+"<div class="py-8 flex flex-col gap-8"><div class="flex flex-col gap-8"><p><a href="https://example.com" target="_blank" rel="noopener noreferrer" class="cursor-pointer text-blue-1000 active:text-orange-700 visited:text-magenta-900 focus-visible:outline-4 focus-visible:outline-black focus-visible:ring-yellow-300 focus-visible:outline-offset-[calc(2/16*1rem)] focus-visible:ring-[calc(2/16*1rem)] focus-visible:bg-yellow-300 focus-visible:rounded-sm underline underline-offset-[calc(3/16*1rem)] hover:decoration-[calc(3/16*1rem)] disabled:border-solid-gray-500 [overflow-wrap:anywhere]">AWSドキュメント:AWS PrivateLink<span aria-hidden="true" data-new-tab="true" class="!text-[16px] font-icon font-light inline-block leading-none align-middle whitespace-nowrap ml-0.5">open_in_new</span><span class="sr-only">Opens in new tab</span></a></p>
 </div></div>"
 `;
 

--- a/packages/markdown/tests/image.test.ts
+++ b/packages/markdown/tests/image.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '../src/render'
+
+const html = (markdown: string) => render(markdown).html
+const style = (markdown: string) => /style="([^"]*)"/.exec(html(markdown))?.[1]
+
+/**
+ * `::img` is the Markdown image plus a size. A document that needs one reaches
+ * for raw HTML and an inline style otherwise.
+ */
+describe('img', () => {
+  it('should render the source and the alternative text', () => {
+    const out = html('::img{src=/a.png alt="A field at dawn"}')
+    expect(out).toContain('src="/a.png"')
+    expect(out).toContain('alt="A field at dawn"')
+  })
+
+  it('should take no size', () => {
+    expect(style('::img{src=/a.png alt=図}')).toBeUndefined()
+  })
+
+  it('should draw at the width asked for', () => {
+    expect(style('::img{src=/a.png alt=図 width=520}')).toBe(
+      'width:520px; max-width:100%;'
+    )
+  })
+
+  it('should keep the image inside a narrow column', () => {
+    // Without max-width a fixed width overflows on a phone.
+    expect(style('::img{src=/a.png alt=図 width=1200}')).toContain(
+      'max-width:100%'
+    )
+  })
+
+  it('should draw at the height asked for', () => {
+    expect(style('::img{src=/a.png alt=図 height=300}')).toBe('height:300px;')
+  })
+
+  it('should take both', () => {
+    expect(style('::img{src=/a.png alt=図 width=520 height=300}')).toBe(
+      'width:520px; height:300px; max-width:100%;'
+    )
+  })
+
+  it('should survive the sanitiser', () => {
+    // width and max-width are on the CSS allowlist; a property that is not
+    // would be dropped here rather than in the renderer.
+    expect(html('::img{src=/a.png alt=図 width=520}')).toContain('520px')
+  })
+
+  it('should refuse a javascript URL', () => {
+    expect(html('::img{src=javascript:alert(1) alt=図}')).not.toContain(
+      'javascript:'
+    )
+  })
+
+  it('should answer to {#name}', () => {
+    expect(html('::img{#figure-1 src=/a.png alt=図}')).toContain('id="figure-1"')
+  })
+
+  it('should be empty alt when none is given', () => {
+    expect(html('::img{src=/a.png}')).toContain('alt=""')
+  })
+})

--- a/packages/markdown/tests/sanitize.test.ts
+++ b/packages/markdown/tests/sanitize.test.ts
@@ -135,6 +135,23 @@ describe('sanitize', () => {
       expect(out).toContain('rel="noopener noreferrer"')
     })
 
+    it('should keep a rel the document asked for as well', () => {
+      const out = html(
+        '<a href="https://example.com" target="_blank" rel="nofollow">外部</a>'
+      )
+      const rel = /rel="([^"]*)"/.exec(out)?.[1].split(' ')
+      expect(rel).toContain('noopener')
+      expect(rel).toContain('noreferrer')
+      expect(rel).toContain('nofollow')
+    })
+
+    it('should not repeat a rel the document already asked for', () => {
+      const out = html(
+        '<a href="https://example.com" target="_blank" rel="noopener">外部</a>'
+      )
+      expect(out).toContain('rel="noopener noreferrer"')
+    })
+
     it('should say that the link opens elsewhere', () => {
       const out = html('[外部](https://example.com)')
       expect(out).toContain('Opens in new tab')


### PR DESCRIPTION
## Why

`![alt](src)` has nowhere to put a size, so a document that needs one falls back to raw HTML and an inline style.

## What

`::img` takes `src`, `alt`, `width` and `height`. Width and height are pixels; either on its own leaves the other to follow the proportions of the image.

```
::img{src=/photo.jpg alt="A field at dawn" width=520}
```

```html
<img src="/photo.jpg" alt="A field at dawn" style="width:520px; max-width:100%;" data-sakura="img">
```

A width also caps the image at the width of its column, so a number larger than the screen shrinks rather than overflowing.

An empty `alt` now reaches the markup, on `card-img` and `cell-img` as well. It marks an image as decoration; leaving the attribute off instead makes a screen reader read the file name.

The marker attributes are renamed after what they mark, and none of them carries the library name any more.

| before | after | |
|---|---|---|
| `data-sakura="card-title"` | `data-styled="card-title"` | the element is dressed; the styling pass leaves it alone |
| `data-sakura-new-tab` | `data-new-tab` | the icon on a link that opens elsewhere |
| `data-sakura-table-container` | `data-table-container` | the box a wide table scrolls inside |

Nothing reads them from outside the package.

### rel on a link that opens elsewhere

`Link` set `target="_blank"` and no `rel`, so the page it opened held a handle on the one that opened it. It gets `rel="noopener noreferrer"`, merged with whatever the caller asked for.

```diff
-<a target="_blank">
+<a target="_blank" rel="noopener noreferrer">
```

The markdown package set the same `rel` by overwriting whatever the document had; it merges too.

## Verification

`pnpm lint`, `pnpm build`, `pnpm test` pass; 143 tests across the workspace, 16 of them new.

Rendered in a browser at two widths, with the example document's `{width=320}` image:

| viewport | column | drawn | overflows |
|---|---|---|---|
| 1400px | 652px | 320×400 | no |
| 375px | 327px | 320×400 | no |

`width` and `max-width` are both on the sanitiser's CSS allowlist, so the style survives it.

`@sakura-ui/core` 0.5.3, `@sakura-ui/markdown` 0.4.3, root 0.5.5.

---

# 日本語

## WHY

`![alt](src)` にはサイズを書く場所がないため、必要な記事は生 HTML とインラインスタイルに逃げていました。

## WHAT

`::img` が `src` / `alt` / `width` / `height` を受け取ります。width と height はピクセルで、片方だけを書けばもう片方は画像の比率に従います。

```
::img{src=/photo.jpg alt="A field at dawn" width=520}
```

```html
<img src="/photo.jpg" alt="A field at dawn" style="width:520px; max-width:100%;" data-sakura="img">
```

width を指定すると列幅も上限になるため、画面より大きい数値を書いても溢れずに縮みます。

空の `alt` がマークアップに届くようになります（`card-img` と `cell-img` も同様）。空の alt は装飾画像であることを示します。属性ごと省くと、スクリーンリーダーがファイル名を読み上げます。

目印の属性を、何を示すものかが分かる名前に改めます。ライブラリ名は含めません。

| 変更前 | 変更後 | |
|---|---|---|
| `data-sakura="card-title"` | `data-styled="card-title"` | 装飾済み。装飾のパスが飛ばす |
| `data-sakura-new-tab` | `data-new-tab` | 新しいタブで開くリンクのアイコン |
| `data-sakura-table-container` | `data-table-container` | 幅の広い表がスクロールする容器 |

いずれもパッケージの外から参照されていません。

### 別タブで開くリンクの rel

`Link` は `target="_blank"` を出しながら `rel` を出していなかったため、開かれたページが開いた側への参照を持てる状態でした。`rel="noopener noreferrer"` が付きます。呼び出し側が渡した `rel` は結合して残します。

```diff
-<a target="_blank">
+<a target="_blank" rel="noopener noreferrer">
```

markdown 側は同じ `rel` を上書きで設定していました。こちらも結合するようにします。

## 検証

`pnpm lint` / `pnpm build` / `pnpm test` が通ります。ワークスペース全体で 143 件、うち 16 件が新規。

examples の `{width=320}` の画像を 2 つの幅で描画しました。

| ビューポート | 列幅 | 描画サイズ | 溢れ |
|---|---|---|---|
| 1400px | 652px | 320×400 | なし |
| 375px | 327px | 320×400 | なし |

`width` と `max-width` はどちらもサニタイザの CSS 許可リストに含まれるため、style は残ります。

`@sakura-ui/core` 0.5.3、`@sakura-ui/markdown` 0.4.3、root 0.5.5。
