### PR TITLE
fix: nest the table of contents under the heading each entry belongs to

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/sakura-ui",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "keywords": [],
   "author": "glassonion1",
   "homepage": "https://github.com/glassonion1/sakura-ui",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sakura-ui/markdown",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "",
   "keywords": [
     "markdown"

--- a/packages/markdown/src/decorate.ts
+++ b/packages/markdown/src/decorate.ts
@@ -1,4 +1,5 @@
 import { styles } from '@sakura-ui/core'
+import { treefy } from '@sakura-ui/helper'
 import Slugger from 'github-slugger'
 import { classNames } from './marked/html'
 
@@ -165,7 +166,10 @@ export const decorate = (
     container.appendChild(table)
   }
 
+  // Nested, so that the table of contents can show a heading under the one it
+  // belongs to. Cut to depth before nesting: filtering the tree afterwards
+  // would only reach the headings sitting at its root.
   return {
-    headings: flat.filter((h) => h.depth <= tocMaxDepth) as HeadingItem[]
+    headings: treefy(flat.filter((h) => h.depth <= tocMaxDepth))
   }
 }

--- a/packages/markdown/tests/Markdown.test.tsx
+++ b/packages/markdown/tests/Markdown.test.tsx
@@ -101,6 +101,23 @@ describe('Markdown', () => {
       expect(html).toMatchSnapshot()
     })
 
+    // The nesting is read from the DOM rather than left to the snapshot, so a
+    // return to one flat list says which shape was lost.
+    it('should put a heading under the one it belongs to', async () => {
+      render(<Markdown showToc>{'# 章1\n\n## 節1\n\n## 節2\n\n# 章2'}</Markdown>)
+      const toc = await screen.findByRole('navigation')
+
+      const chapters = toc.querySelectorAll(':scope > ul > li')
+      expect(
+        Array.from(chapters, (li) => li.querySelector('a')?.textContent)
+      ).toEqual(['章1', '章2'])
+
+      const sections = chapters[0].querySelectorAll(':scope > ul > li')
+      expect(
+        Array.from(sections, (li) => li.querySelector('a')?.textContent)
+      ).toEqual(['節1', '節2'])
+    })
+
     it('should use the given title', async () => {
       render(
         <Markdown showToc tocTitle="もくじ">

--- a/packages/markdown/tests/__snapshots__/Markdown.test.tsx.snap
+++ b/packages/markdown/tests/__snapshots__/Markdown.test.tsx.snap
@@ -301,7 +301,12 @@ exports[`Markdown > table of contents > should render the table of contents when
   
   disabled:border-solid-gray-500
   [overflow-wrap:anywhere]
-" href="#章1">章1</a></li><li><a class="
+" href="#章1">章1</a><ul class="
+  list-disc
+  [&amp;_&amp;]:list-circle
+  [&amp;_&amp;_&amp;]:list-square
+  pl-8
+"><li><a class="
   cursor-pointer
   text-blue-1000
   active:text-orange-700
@@ -355,7 +360,7 @@ exports[`Markdown > table of contents > should render the table of contents when
   
   disabled:border-solid-gray-500
   [overflow-wrap:anywhere]
-" href="#節2">節2</a></li><li><a class="
+" href="#節2">節2</a></li></ul></li><li><a class="
   cursor-pointer
   text-blue-1000
   active:text-orange-700


### PR DESCRIPTION
## Why

The table of contents drew every heading as a sibling of every other, whatever
its level, so a reader could not see which section a subsection belonged to.

The move to marked (b13ff78) rebuilt the pipeline around `decorate`, and the
call that turned the flat list of headings into a tree did not come across with
it. `decorate` returned `flat.filter((h) => h.depth <= tocMaxDepth)`.
`TableOfContents` still draws a nested `<Ul>` for an entry that has children,
but nothing filled `children` in any more, so that branch was dead code and the
contents came out flat.

`treefy` had a bug of its own until PR #21 — it pushed children into a throwaway
array and dropped them — which is why the contents used to show only the top
level. That is fixed; it was simply no longer being called.

## What

`decorate` nests the headings again, after the `tocMaxDepth` cut. Filtering
afterwards would only reach the entries at the root of the tree.

```
# 章1 / ## 節1 / ### 項1 / ## 節2 / # 章2   (tocMaxDepth: 2)

before                after
- 章1                 - 章1
- 節1                   - 節1
- 節2                   - 節2
- 章2                 - 章2
```

The nesting also has a test that reads the DOM rather than leaving it to the
snapshot, so a return to one flat list says which shape was lost.

## Verification

- `pnpm test` — 103 passed (5 files); the table of contents snapshot updated to
  the nested markup.
- `pnpm lint` — clean.
- `pnpm build` — 6 tasks successful.

---

# 日本語

## WHY

目次が見出しのレベルに関係なくすべて同じ階層の兄弟として並んでいて、どの節が
どの章に属するのか読み取れませんでした。

marked への移行 (b13ff78) でパイプラインを `decorate` 中心に組み直した際、
フラットな見出し配列をツリーに変換する処理が移植から漏れていました。
`decorate` は `flat.filter((h) => h.depth <= tocMaxDepth)` を返すだけです。
`TableOfContents` は今も `children` があれば入れ子の `<Ul>` を描きますが、
`children` を埋めるコードが無くなったためこの分岐は到達不能で、目次はフラット
なままでした。

なお `treefy` 自体にも PR #21 まで別のバグがあり（子を使い捨て配列に push して
捨てていた）、それが「従来 1 レベルしか表示されなかった」理由です。こちらは
修正済みで、単に呼ばれなくなっていただけです。

## WHAT

`decorate` で `tocMaxDepth` による絞り込みの後にツリー化を行います。順序が逆だと
ツリーのルートしか見ないため、`tocMaxDepth` が子孫に効きません。

入れ子構造はスナップショット任せにせず DOM を直接検証するテストも追加しました。
フラットに戻った場合に、どの形が失われたのかが分かります。

## 検証

- `pnpm test` — 103 passed (5 files)。目次のスナップショットが入れ子の markup に更新。
- `pnpm lint` — 指摘なし。
- `pnpm build` — 6 tasks 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtuA7YBVHGvmq3HxwFnjCS
